### PR TITLE
[feature] progressive mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <climits> // for INT_MAX
 #include <cmath> // For std::sqrt and so on
 #include <vector>
 #include <string>
@@ -70,9 +71,16 @@ void tonemap(std::vector<sRGBPixel> &image_LDR, const std::vector<vec3f> &image_
 
 int main(int argc, char ** argv)
 {
-	// Squash -Wunused-parameter
-	(void) argc;
-	(void) argv;
+	// parse command line arguments
+	enum { mode_progressive, mode_animation } mode = mode_animation;
+	if (argc > 1)
+	{
+		if (std::string(argv[1]) == "--progressive")
+		{
+			mode = mode_progressive;
+		}
+	}
+
 	std::vector<Sphere> spheres;
 	{
 		const real main_sphere_rad = 4;
@@ -112,32 +120,64 @@ int main(int argc, char ** argv)
 	const int image_multi  = 40;
 	const int image_width  = image_multi * 16;
 	const int image_height = image_multi * 9;
-	const int frames = 30 * 8;
-	const int passes = 2 * 3 * 5;
-	printf("Rendering %d frames at resolution %d x %d with %d passes\n", frames, image_width, image_height, passes);
-
 
 	std::vector<vec3f>     image_HDR(image_width * image_height);
 	std::vector<sRGBPixel> image_LDR(image_width * image_height);
 
-	for (int frame = 0; frame < frames; ++frame)
+	switch (mode)
 	{
-		std::fill(image_HDR.begin(), image_HDR.end(), vec3f{ 0,0,0 });
-
-		// Render image passes
-		for (int pass = 0; pass < passes; ++pass)
+		case mode_animation:
 		{
-			render_pass(image_HDR, frame, pass, image_width, image_height, frames, world);
+			const int frames = 30 * 8;
+			const int passes = 2 * 3 * 5;
+			printf("Rendering %d frames at resolution %d x %d with %d passes\n", frames, image_width, image_height, passes);
+			for (int frame = 0; frame < frames; ++frame)
+			{
+				std::fill(image_HDR.begin(), image_HDR.end(), vec3f{ 0,0,0 });
+		
+				// Render image passes
+				for (int pass = 0; pass < passes; ++pass)
+				{
+					render_pass(image_HDR, frame, pass, image_width, image_height, frames, world);
+				}
+		
+				// Tonemap and convert to LDR sRGB
+				tonemap(image_LDR, image_HDR, passes, image_width, image_height);
+		
+				// Save frame
+				char filename[64];
+				snprintf(filename, 64, "frame_%08d.png", frame);
+				stbi_write_png(filename, image_width, image_height, 3, &image_LDR[0], image_width * 3);
+				printf("Saved %s\n", filename);
+			}
+			break;
 		}
 
-		// Tonemap and convert to LDR sRGB
-		tonemap(image_LDR, image_HDR, passes, image_width, image_height);
+		case mode_progressive:
+		{
+			printf("Progressive rendering at resolution %d x %d with doubling passes\n", image_width, image_height);
+			int pass = 0;
+			std::fill(image_HDR.begin(), image_HDR.end(), vec3f{ 0,0,0 });
+			for (int passes = 1; true; passes <<= 1)
+			{
+				// Render image passes
+				for (; pass < passes; ++pass)
+				{
+					// frame/frames 0/INT_MAX to reduce motion blur for still image
+					render_pass(image_HDR, 0, pass, image_width, image_height, INT_MAX, world);
+				}
 
-		// Save frame
-		char filename[64];
-		snprintf(filename, 64, "frame_%08d.png", frame);
-		stbi_write_png(filename, image_width, image_height, 3, &image_LDR[0], image_width * 3);
-		printf("Saved %s\n", filename);
+				// Tonemap and convert to LDR sRGB
+				tonemap(image_LDR, image_HDR, passes, image_width, image_height);
+
+				// Save frame
+				char filename[64];
+				snprintf(filename, 64, "pass_%08d.png", pass);
+				stbi_write_png(filename, image_width, image_height, 3, &image_LDR[0], image_width * 3);
+				printf("Saved %s\n", filename);
+			}
+			break;
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
add a `--progressive` mode (as opposed to `--animation`, which remains the default)

factors out some common code to new functions `render_pass()` and `tonemap()`.

progressive mode saves to separate files, this could be changed back to single-file-overwrite if desired

progressive passes are increased by doubling

motion blur is reduced by setting frame count to `INT_MAX`, this could be done a nicer way with shutter time and FPS settings, this is just a simple hack
