### PR TITLE
[feature] hybrid distance estimator

### DIFF
--- a/src/Mandelbulb.h
+++ b/src/Mandelbulb.h
@@ -75,6 +75,10 @@ struct MandelbulbDual final : public DualDEObject
 				break;
 		}
 
+#if 1
+		return getHybridDE(1, 8, w, normal_os_out);
+#else
 		return getPolynomialDE(w, normal_os_out);
+#endif
 	}
 };

--- a/src/MengerSponge.h
+++ b/src/MengerSponge.h
@@ -72,6 +72,10 @@ struct MengerSpongeDual final : public DualDEObject
 				break;
 		}
 
+#if 1
+		return getHybridDE(3, 1, z, normal_os_out);
+#else
 		return getLinearDE(z, normal_os_out);
+#endif
 	}
 };

--- a/src/QuadraticJuliabulb.h
+++ b/src/QuadraticJuliabulb.h
@@ -58,6 +58,10 @@ struct QuadraticJuliabulbDual final : public DualDEObject
 			z = { zx_, zy_, zz_ };
 		}
 
+#if 1
+		return getHybridDE(1, 2, z, normal_os_out);
+#else
 		return 0.125f * getPolynomialDE(z, normal_os_out);
+#endif
 	}
 };


### PR DESCRIPTION
Implement and use the hybrid distance estimator with arguments for `a` and `p` for behaviour near infinity like `z -> a z^p`.  There are no hybrid fractals yet, and the special cases for a=1 and p=1 are the same as previous implementations `getLinearDE()` and `getPolynomialDE()`, so unsurprisingly it seems to work fine.