### PR TITLE
triplex algebra

### DIFF
--- a/src/Dual.h
+++ b/src/Dual.h
@@ -236,3 +236,10 @@ inline constexpr Dual<real_type, vars> max(const Dual<real_type, vars> & p, cons
 {
 	return (p.v[0] > max_val) ? max_val : p; // Note: zero derivs right of max_val
 }
+
+
+template <typename real_type, int vars>
+inline constexpr Dual<real_type, vars> sqr(const Dual<real_type, vars> & p)
+{
+	return p * p; // TODO optimize
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-FractalTracer: Amazingbox.h AnalyticDEObject.h BenesiPine2.h Cubicbulb.h Dual.h DualDEObject.h main.cpp MandalayKIFS.h Mandelbulb.h MengerSponge.h MengerSpongeC.h Material.h Octopus.h PseudoKleinian.h QuadraticJuliabulb.h Ray.h real.h Renderer.h RiemannSphere.h Scene.h SceneObject.h SimpleObjects.h stb_image_write.h vec.h
+FractalTracer: Amazingbox.h AnalyticDEObject.h BenesiPine2.h Cubicbulb.h Dual.h DualDEObject.h main.cpp MandalayKIFS.h Mandelbulb.h MengerSponge.h MengerSpongeC.h Material.h Octopus.h PseudoKleinian.h QuadraticJuliabulb.h Ray.h real.h Renderer.h RiemannSphere.h Scene.h SceneObject.h SimpleObjects.h stb_image_write.h triplex.h vec.h
 	g++ -std=c++17 -Wall -Wextra -pedantic -O3 -march=native -fopenmp -o FractalTracer main.cpp
 
 clean:

--- a/src/Mandelbulb.h
+++ b/src/Mandelbulb.h
@@ -3,6 +3,7 @@
 #include "AnalyticDEObject.h"
 #include "DualDEObject.h"
 
+#include "triplex.h"
 
 
 // Inigo Quilez's power 8 Mandelbulb distance estimator
@@ -122,4 +123,28 @@ struct DualMandelbulbIteration final : public IterationFunction
 
 private:
 	DualVec3r c;
+};
+
+
+struct DualTriplexMandelbulbIteration final : public IterationFunction
+{
+	virtual void init(const DualVec3r & p_0) noexcept override final
+	{
+		c = dualtriplex3r(p_0);
+	}
+
+	virtual void eval(const DualVec3r & p_in, DualVec3r & p_out) const noexcept override final
+	{
+		p_out = sqr(sqr(sqr(dualtriplex3r(p_in)))) + c;
+	}
+
+	virtual real getPower() const noexcept override final { return 8; }
+
+	virtual IterationFunction * clone() const override final
+	{
+		return new DualTriplexMandelbulbIteration(*this);
+	}
+
+private:
+	dualtriplex3r c;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -129,6 +129,7 @@ int main(int argc, char ** argv)
 #else
 		DualPseudoKleinianIteration pki;
 		DualMandelbulbIteration mbi;
+		DualTriplexMandelbulbIteration mbti;
 		DualMengerSpongeCIteration msi; //msi.stc.x = 1.5f; msi.stc.y = 0.75f; msi.scale = 2.8f;
 		DualCubicbulbIteration cbi;
 		DualAmazingboxIteration ai; //ai.scale = 1.75f;
@@ -141,6 +142,7 @@ int main(int argc, char ** argv)
 		iter_funcs.push_back(oi.clone());
 		//iter_funcs.push_back(pki.clone());
 		iter_funcs.push_back(mbi.clone());
+		//iter_funcs.push_back(mbti.clone());
 		//iter_funcs.push_back(msi.clone());
 		//iter_funcs.push_back(ai.clone());
 		//iter_funcs.push_back(cbi.clone());

--- a/src/real.h
+++ b/src/real.h
@@ -23,3 +23,7 @@ constexpr real real_inf = std::numeric_limits<real>::infinity();
 constexpr real pi = static_cast<real>(3.141592653589793238462643383279);
 constexpr real pi_half = static_cast<real>(1.5707963267948966192313216916398);
 constexpr real two_pi = static_cast<real>(6.283185307179586476925286766559);
+
+
+inline float sqr(float a) { return a * a; }
+inline double sqr(double a) { return a * a; }

--- a/src/triplex.h
+++ b/src/triplex.h
@@ -16,59 +16,59 @@ struct triplex
   inline triplex(const real_type &x) : v(x, real_type(0), real_type(0)) { }
   inline triplex() { } // uninitialized is a good thing? not sure..
 
-  operator const vec<3, real_type> & () const { return v; }
+  inline operator const vec<3, real_type> & () const { return v; }
 
-  triplex & operator=(const triplex &t) = default;
+  inline triplex & operator=(const triplex &t) = default;
 
-  const real_type & x() const { return v.x(); }
-  const real_type & y() const { return v.y(); }
-  const real_type & z() const { return v.z(); }
+  inline const real_type & x() const { return v.x(); }
+  inline const real_type & y() const { return v.y(); }
+  inline const real_type & z() const { return v.z(); }
 };
 
 template <typename real_type>
-triplex<real_type> operator+(const triplex<real_type> &a, const triplex<real_type> &b)
+inline triplex<real_type> operator+(const triplex<real_type> &a, const triplex<real_type> &b)
 {
   return a.v + b.v;
 }
 
 template <typename real_type>
-triplex<real_type> operator-(const triplex<real_type> &a, const triplex<real_type> &b)
+inline triplex<real_type> operator-(const triplex<real_type> &a, const triplex<real_type> &b)
 {
   return a.v - b.v;
 }
 
 template <typename real_type>
-triplex<real_type> operator-(const triplex<real_type> &b)
+inline triplex<real_type> operator-(const triplex<real_type> &b)
 {
   return -b.v;
 }
 
 template <typename real_type>
-triplex<real_type> operator*(const triplex<real_type> &a, const real_type &b)
+inline triplex<real_type> operator*(const triplex<real_type> &a, const real_type &b)
 {
   return a.v * b;
 }
 
 template <typename real_type>
-triplex<real_type> operator*(const real_type &a, const triplex<real_type> &b)
+inline triplex<real_type> operator*(const real_type &a, const triplex<real_type> &b)
 {
   return a * b.v;
 }
 
 template <typename real_type>
-triplex<real_type> operator/(const triplex<real_type> &a, const real_type &b)
+inline triplex<real_type> operator/(const triplex<real_type> &a, const real_type &b)
 {
   return a.v * (1/b);
 }
 
 template <typename real_type>
-triplex<real_type> operator/(const real_type &a, const triplex<real_type> &b)
+inline triplex<real_type> operator/(const real_type &a, const triplex<real_type> &b)
 {
   return (1/a) * b.v;
 }
 
 template <typename real_type>
-triplex<real_type> length2(const triplex<real_type> &a)
+inline triplex<real_type> length2(const triplex<real_type> &a)
 {
   return length2(a.v);
 }
@@ -76,7 +76,7 @@ triplex<real_type> length2(const triplex<real_type> &a)
 // custom triplex operations
 
 template <typename real_type>
-triplex<real_type> operator*(const triplex<real_type> &a, const triplex<real_type> &b)
+inline triplex<real_type> operator*(const triplex<real_type> &a, const triplex<real_type> &b)
 {
   real_type arho(sqrt(sqr(a.x()) + sqr(a.y())));
   real_type brho(sqrt(sqr(b.x()) + sqr(b.y())));
@@ -89,7 +89,7 @@ triplex<real_type> operator*(const triplex<real_type> &a, const triplex<real_typ
 }
 
 template <typename real_type>
-triplex<real_type> operator/(const triplex<real_type> &a, const triplex<real_type> &b)
+inline triplex<real_type> operator/(const triplex<real_type> &a, const triplex<real_type> &b)
 {
   real_type arho(sqrt(sqr(a.x()) + sqr(a.y())));
   real_type brho(sqrt(sqr(b.x()) + sqr(b.y())));
@@ -102,7 +102,7 @@ triplex<real_type> operator/(const triplex<real_type> &a, const triplex<real_typ
 }
 
 template <typename real_type>
-triplex<real_type> sqr(const triplex<real_type> &a)
+inline triplex<real_type> sqr(const triplex<real_type> &a)
 {
   real_type x2(sqr(a.x()));
   real_type y2(sqr(a.y()));

--- a/src/triplex.h
+++ b/src/triplex.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "vec.h"
+
+// lifted vector operations
+
+template <typename real_type>
+struct triplex
+{
+  vec<3, real_type> v;
+
+  inline triplex(const triplex &t) : v(t.v) { }
+  inline triplex(const vec<3, real_type> v) : v(v) { }
+  inline triplex(const real_type &x, const real_type &y, const real_type &z) : v(x, y, z) { }
+  inline triplex(const real_type &x, const real_type &y) : v(x, y, real_type(0)) { }
+  inline triplex(const real_type &x) : v(x, real_type(0), real_type(0)) { }
+  inline triplex() { } // uninitialized is a good thing? not sure..
+
+  operator const vec<3, real_type> & () const { return v; }
+
+  triplex & operator=(const triplex &t) = default;
+
+  const real_type & x() const { return v.x(); }
+  const real_type & y() const { return v.y(); }
+  const real_type & z() const { return v.z(); }
+};
+
+template <typename real_type>
+triplex<real_type> operator+(const triplex<real_type> &a, const triplex<real_type> &b)
+{
+  return a.v + b.v;
+}
+
+template <typename real_type>
+triplex<real_type> operator-(const triplex<real_type> &a, const triplex<real_type> &b)
+{
+  return a.v - b.v;
+}
+
+template <typename real_type>
+triplex<real_type> operator-(const triplex<real_type> &b)
+{
+  return -b.v;
+}
+
+template <typename real_type>
+triplex<real_type> operator*(const triplex<real_type> &a, const real_type &b)
+{
+  return a.v * b;
+}
+
+template <typename real_type>
+triplex<real_type> operator*(const real_type &a, const triplex<real_type> &b)
+{
+  return a * b.v;
+}
+
+template <typename real_type>
+triplex<real_type> operator/(const triplex<real_type> &a, const real_type &b)
+{
+  return a.v * (1/b);
+}
+
+template <typename real_type>
+triplex<real_type> operator/(const real_type &a, const triplex<real_type> &b)
+{
+  return (1/a) * b.v;
+}
+
+template <typename real_type>
+triplex<real_type> length2(const triplex<real_type> &a)
+{
+  return length2(a.v);
+}
+
+// custom triplex operations
+
+template <typename real_type>
+triplex<real_type> operator*(const triplex<real_type> &a, const triplex<real_type> &b)
+{
+  real_type arho(sqrt(sqr(a.x()) + sqr(a.y())));
+  real_type brho(sqrt(sqr(b.x()) + sqr(b.y())));
+  real_type A(real_type(1) - a.z() * b.z() / (arho * brho));
+  return
+    { A * (a.x() * b.x() - a.y() * b.y())
+    , A * (a.x() * b.y() + a.y() * b.x())
+    , arho * b.z() + brho * a.z()
+    };
+}
+
+template <typename real_type>
+triplex<real_type> operator/(const triplex<real_type> &a, const triplex<real_type> &b)
+{
+  real_type arho(sqrt(sqr(a.x()) + sqr(a.y())));
+  real_type brho(sqrt(sqr(b.x()) + sqr(b.y())));
+  real_type A(real_type(1) + a.z() * b.z() / (arho * brho));
+  return triplex<real_type>
+    ( A * (a.x() * b.x() + a.y() * b.y())
+    , A * (a.y() * b.x() - a.x() * b.y())
+    , brho * a.z() - arho * b.z()
+    ) / length2(b);
+}
+
+template <typename real_type>
+triplex<real_type> sqr(const triplex<real_type> &a)
+{
+  real_type x2(sqr(a.x()));
+  real_type y2(sqr(a.y()));
+  real_type arho2 = x2 + y2;
+  real_type A = real_type(1) - sqr(a.z()) / arho2;
+  return triplex<real_type>
+    ( A * (x2 - y2)
+    , A * real_type(2) * a.x() * a.y()
+    , real_type(2) * sqrt(arho2) * a.z()
+    );
+}
+
+using triplexi = triplex<int>;
+using triplexr = triplex<real>;
+using triplexf = triplex<float>;
+using triplexd = triplex<double>;
+
+using dualtriplex3r = triplex<Dual3r>;
+using dualtriplex3f = triplex<Dual3f>;
+using dualtriplex3d = triplex<Dual3d>;


### PR DESCRIPTION
a header with triplex algebra, essentially a vec3 with custom `*` and `/`

allows simple definition of Mandelbulb (one-liner)

but it is 65% slower on my machine (24s per pass vs 14s per pass for the existing dual version).  not sure why.

and it looks different, also not sure why.  maybe connected...

may be interesting anyway, to show diversity of approaches?

ref for the maths: http://www.fractalforums.com/theory/non-trigonometric-expansions-for-cosine-formula/