### PR TITLE
Demo cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,76 @@
 src/FractalTracer
 *.ipch
 *.suo
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+

--- a/src/demo/main.cpp
+++ b/src/demo/main.cpp
@@ -154,7 +154,7 @@ int main(int argc, char ** argv)
 		//iter_funcs.push_back(bp2.clone());
 		iter_funcs.push_back(sti.clone());
 
-		const std::vector<char> iter_seq = { 0 };
+		const std::vector<char> iter_seq = { 0, 1 };
 
 		const int max_iters = 64;
 		GeneralDualDE hybrid(max_iters, iter_funcs, iter_seq);
@@ -250,8 +250,7 @@ int main(int argc, char ** argv)
 
 		case mode_progressive:
 		{
-			//const int max_passes = 2 * 3 * 5 * 7 * 11; // Set a reasonable max number of passes instead of going forever
-			const int max_passes = 6; // Set something more reasonable for quick test
+			const int max_passes = 2 * 3 * 5 * 7 * 11; // Set a reasonable max number of passes instead of going forever
 			printf("Progressive rendering at resolution %d x %d with doubling passes to max %d\n", image_width, image_height, max_passes);
 			output.clear();
 

--- a/src/demo/main.cpp
+++ b/src/demo/main.cpp
@@ -145,9 +145,9 @@ int main(int argc, char ** argv)
 		std::vector<IterationFunction *> iter_funcs;
 		//iter_funcs.push_back(oi.clone());
 		//iter_funcs.push_back(pki.clone());
-		//iter_funcs.push_back(mbi.clone());
+		iter_funcs.push_back(mbi.clone());
 		//iter_funcs.push_back(mbti.clone());
-		//iter_funcs.push_back(msi.clone());
+		iter_funcs.push_back(msi.clone());
 		//iter_funcs.push_back(ai.clone());
 		//iter_funcs.push_back(cbi.clone());
 		//iter_funcs.push_back(dki.clone());

--- a/src/demo/main.cpp
+++ b/src/demo/main.cpp
@@ -92,7 +92,7 @@ int main(int argc, char ** argv)
 #else
 	const int num_threads = (int)std::thread::hardware_concurrency();
 #endif
-	const bool do_timing = true;
+	const bool print_timing = true;
 
 	// Parse command line arguments
 	enum { mode_progressive, mode_animation } mode = mode_progressive;
@@ -233,7 +233,7 @@ int main(int argc, char ** argv)
 
 				renderPasses(threads, output, frame, 0, passes, frames, scene);
 
-				if (do_timing)
+				if (print_timing)
 				{
 					std::chrono::high_resolution_clock::time_point t2 = std::chrono::high_resolution_clock::now();
 					std::chrono::duration<double> time_span = std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
@@ -250,33 +250,38 @@ int main(int argc, char ** argv)
 
 		case mode_progressive:
 		{
-			const int max_passes = 2 * 3 * 5 * 7 * 11; // Set a reasonable max number of passes instead of going forever
+			//const int max_passes = 2 * 3 * 5 * 7 * 11; // Set a reasonable max number of passes instead of going forever
+			const int max_passes = 6; // Set something more reasonable for quick test
 			printf("Progressive rendering at resolution %d x %d with doubling passes to max %d\n", image_width, image_height, max_passes);
 			output.clear();
 
-			int pass = 0;
 			int target_passes = 1;
-			while (pass < max_passes)
+			int total_passes = 0;
+
+			std::chrono::nanoseconds total_time;
+
+			while (total_passes < max_passes)
 			{
-				std::chrono::high_resolution_clock::time_point t1 = std::chrono::high_resolution_clock::now();
+				const auto t1 = std::chrono::steady_clock::now();
 
 				// Note that we force num_frames to be zero since we usually don't want motion blur for stills
-				const int num_passes = target_passes - pass;
-				renderPasses(threads, output, 0, pass, num_passes, 0, scene);
+				const int num_passes = target_passes - total_passes;
+				renderPasses(threads, output, 0, total_passes, num_passes, 0, scene);
+				total_passes += num_passes;
+				target_passes = std::min(target_passes * 2, max_passes);
 
-				if (do_timing)
+				const auto t2 = std::chrono::steady_clock::now();
+				total_time += t2 - t1;
+
+				if (print_timing)
 				{
-					std::chrono::high_resolution_clock::time_point t2 = std::chrono::high_resolution_clock::now();
-					std::chrono::duration<double> time_span = std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
+					const auto time_span = std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
 					printf("%d passes took %.2f seconds (%.2f seconds per pass).\n", num_passes, time_span.count(), time_span.count() / num_passes);
 				}
 
-				save_tonemapped_buffer("beauty", 0, target_passes, output.beauty);
-				if (save_normal) save_tonemapped_buffer("normal", 0, target_passes, output.normal);
-				if (save_albedo) save_tonemapped_buffer("albedo", 0, target_passes, output.albedo);
-
-				pass = target_passes;
-				target_passes = std::min(target_passes << 1, max_passes);
+				save_tonemapped_buffer("still_beauty", total_passes, target_passes, output.beauty);
+				if (save_normal) save_tonemapped_buffer("still_normal", total_passes, total_passes, output.normal);
+				if (save_albedo) save_tonemapped_buffer("still_albedo", total_passes, total_passes, output.albedo);
 			}
 
 			break;


### PR DESCRIPTION
@lycium changes:

- swapped the undependable [`std::chrono::high_resolution_clock`][std_high_res_clock] with [`std::chrono::steady_clock`][std_steady_clock] which is at least guaranteed to be monotonic
- cleaned up the code a little
- enabled the rendering functions you mentioned
- prefix still renders with `still_`
- when rendering stills use total rendering passes so far as frame number when calling `save_tonemapped_buffer()` so that it saves with the number of passes in the filename, I thought it would be cool to have the ability 

[std_high_res_clock]: https://en.cppreference.com/w/cpp/chrono/high_resolution_clock
[std_steady_clock]: https://en.cppreference.com/w/cpp/chrono/steady_clock