### PR TITLE
Add CLI formula selection, output channels, and ffmpeg encoding

### DIFF
--- a/src/demo/main.cpp
+++ b/src/demo/main.cpp
@@ -104,10 +104,16 @@ int main(int argc, char ** argv)
 
 	// Parse command line arguments
 	enum { mode_progressive, mode_animation } mode = mode_progressive;
-	if (argc > 1)
+	bool preview = false;
+	bool box = false;
+	for (int arg = 1; arg < argc; ++arg)
 	{
-		if (std::string(argv[1]) == "--animation")
+		if (std::string(argv[arg]) == "--animation")
 			mode = mode_animation;
+		if (std::string(argv[arg]) == "--preview")
+			preview = true;
+		if (std::string(argv[arg]) == "--box")
+			box = true;
 	}
 
 	Scene scene;
@@ -138,6 +144,7 @@ int main(int argc, char ** argv)
 		//scene.objects.push_back(quad.clone());
 
 
+		if (box)
 		{
 			const real k = main_sphere_rad;
 			Quad q0(vec3r(-k,  k, -k), vec3r(2, 0, 0) * k, vec3r(0, 0, 2) * k); q0.mat.albedo = vec3f(0.7f, 0.7f, 0.7f); q0.mat.use_fresnel = true; scene.objects.push_back(q0.clone()); // top
@@ -225,10 +232,10 @@ int main(int argc, char ** argv)
 			scene.objects.push_back(sp.clone());
 		}
 	}
-
+	const int image_div = preview ? 4 : 1;
 	const int image_multi  = mode == mode_animation ? 40 : 80 * 2;
-	const int image_width  = image_multi * 16;
-	const int image_height = image_multi * 9;
+	const int image_width  = image_multi / image_div * 16;
+	const int image_height = image_multi / image_div * 9;
 	const bool save_normal = false;
 	const bool save_albedo = false;
 
@@ -253,8 +260,8 @@ int main(int argc, char ** argv)
 	{
 		case mode_animation:
 		{
-			const int frames = 30 * 4;
-			const int passes = 2 * 3; // 2 * 3 * 5 * 7;
+			const int frames = preview ? 30 : 30 * 4;
+			const int passes = preview ? 1 : 2 * 3; // 2 * 3 * 5 * 7;
 			printf("Rendering %d frames at resolution %d x %d with %d passes\n", frames, image_width, image_height, passes);
 
 			for (int frame = 0; frame < frames; ++frame)

--- a/src/demo/main.cpp
+++ b/src/demo/main.cpp
@@ -222,7 +222,7 @@ int main(int argc, char ** argv)
 		}
 	}
 
-	const int image_multi  = 80 * 2;
+	const int image_multi  = mode == mode_animation ? 40 : 80 * 2;
 	const int image_width  = image_multi * 16;
 	const int image_height = image_multi * 9;
 	const bool save_normal = false;
@@ -250,7 +250,7 @@ int main(int argc, char ** argv)
 		case mode_animation:
 		{
 			const int frames = 30 * 4;
-			const int passes = 2 * 3 * 5 * 7;
+			const int passes = 2 * 3; // 2 * 3 * 5 * 7;
 			printf("Rendering %d frames at resolution %d x %d with %d passes\n", frames, image_width, image_height, passes);
 
 			for (int frame = 0; frame < frames; ++frame)

--- a/src/demo/main.cpp
+++ b/src/demo/main.cpp
@@ -41,6 +41,8 @@
 #include "formulas/RiemannSphere.h"
 #include "formulas/SphereTree.h"
 #include "formulas/Lambdabulb.h"
+#include "formulas/BurningShip4D.h"
+#include "formulas/Hopfbrot.h"
 
 
 
@@ -146,11 +148,13 @@ int main(int argc, char ** argv)
 			Quad q5(vec3r( k, -k, -k), vec3r(0, 0, 2) * k, vec3r(0, 2, 0) * k); q5.mat.albedo = vec3f(0.02f, 0.8f, 0.05f); q5.mat.use_fresnel = true; scene.objects.push_back(q5.clone()); // right
 		}
 
-#if 0
+#if 1
 		//MengerSpongeCAnalytic bulb;
-		MandelbulbDual bulb;
-		bulb.radius = 1.25f;
-		bulb.step_scale = 1; //0.5f; //
+		//MandelbulbDual bulb;
+		//bulb.radius = 1.25f;
+		Hopfbrot bulb;
+		bulb.radius = 2.0f;
+		bulb.step_scale = 0.5f;
 		bulb.mat.albedo = { 0.1f, 0.3f, 0.7f };
 		bulb.mat.use_fresnel = true;
 		scene.objects.push_back(bulb.clone());

--- a/src/demo/main.cpp
+++ b/src/demo/main.cpp
@@ -106,14 +106,19 @@ int main(int argc, char ** argv)
 	enum { mode_progressive, mode_animation } mode = mode_progressive;
 	bool preview = false;
 	bool box = false;
+	bool save_normal = false;
+	bool save_albedo = false;
+	std::string formula_name = "hopfbrot";
 	for (int arg = 1; arg < argc; ++arg)
 	{
-		if (std::string(argv[arg]) == "--animation")
-			mode = mode_animation;
-		if (std::string(argv[arg]) == "--preview")
-			preview = true;
-		if (std::string(argv[arg]) == "--box")
-			box = true;
+		const std::string a = argv[arg];
+		if (a == "--animation") mode = mode_animation;
+		else if (a == "--preview") preview = true;
+		else if (a == "--box")     box = true;
+		else if (a == "--normal")  save_normal = true;
+		else if (a == "--albedo")  save_albedo = true;
+		else if (a == "--formula" && arg + 1 < argc) formula_name = argv[++arg];
+		else { fprintf(stderr, "Unknown argument: %s\n", argv[arg]); return 1; }
 	}
 
 	Scene scene;
@@ -155,56 +160,66 @@ int main(int argc, char ** argv)
 			Quad q5(vec3r( k, -k, -k), vec3r(0, 0, 2) * k, vec3r(0, 2, 0) * k); q5.mat.albedo = vec3f(0.02f, 0.8f, 0.05f); q5.mat.use_fresnel = true; scene.objects.push_back(q5.clone()); // right
 		}
 
-#if 1
-		//MengerSpongeCAnalytic bulb;
-		//MandelbulbDual bulb;
-		//bulb.radius = 1.25f;
-		Hopfbrot bulb;
-		bulb.radius = 2.0f;
-		bulb.step_scale = 0.5f;
-		bulb.mat.albedo = { 0.1f, 0.3f, 0.7f };
-		bulb.mat.use_fresnel = true;
-		scene.objects.push_back(bulb.clone());
-#else
-		DualPseudoKleinianIteration pki;
-		DualMandelbulbIteration mbi;
-		DualTriplexMandelbulbIteration mbti;
-		DualMengerSpongeCIteration msi; //msi.stc.x = 1.5f; msi.stc.y = 0.75f; msi.scale = 2.8f;
-		DualCubicbulbIteration cbi;
-		DualAmazingboxIteration ai; //ai.scale = 1.75f;
-		DualOctopusIteration oi;
-		DualBenesiPine2Iteration bp2;
-		DualRiemannSphereIteration rs;
-		DualMandalayKIFSIteration dki;
-		DualSphereTreeIteration sti;
-		DualLambdabulbIteration lbi;
+		// Formula dispatch based on --formula flag
+		if (formula_name == "hopfbrot")
+		{
+			Hopfbrot bulb;
+			bulb.radius = 2.0f;
+			bulb.step_scale = 0.5f;
+			bulb.mat.albedo = { 0.1f, 0.3f, 0.7f };
+			bulb.mat.use_fresnel = true;
+			scene.objects.push_back(bulb.clone());
+		}
+		else if (formula_name == "burningship4d")
+		{
+			BurningShip4D bulb;
+			bulb.radius = 2.0f;
+			bulb.mat.albedo = { 0.1f, 0.3f, 0.7f };
+			bulb.mat.use_fresnel = true;
+			scene.objects.push_back(bulb.clone());
+		}
+		else if (formula_name == "mandelbulb")
+		{
+			MandelbulbDual bulb;
+			bulb.radius = 1.25f;
+			bulb.mat.albedo = { 0.1f, 0.3f, 0.7f };
+			bulb.mat.use_fresnel = true;
+			scene.objects.push_back(bulb.clone());
+		}
+		else
+		{
+			// IterationFunction-based formulas wrapped in GeneralDualDE
+			IterationFunction * iter = nullptr;
+			if      (formula_name == "lambdabulb")      iter = new DualLambdabulbIteration;
+			else if (formula_name == "amazingbox")      iter = new DualAmazingboxIteration;
+			else if (formula_name == "octopus")         iter = new DualOctopusIteration;
+			else if (formula_name == "mengersponge")    iter = new DualMengerSpongeCIteration;
+			else if (formula_name == "cubicbulb")       iter = new DualCubicbulbIteration;
+			else if (formula_name == "pseudokleinian")  iter = new DualPseudoKleinianIteration;
+			else if (formula_name == "riemannsphere")   iter = new DualRiemannSphereIteration;
+			else if (formula_name == "mandalay")        iter = new DualMandalayKIFSIteration;
+			else if (formula_name == "spheretree")      iter = new DualSphereTreeIteration;
+			else if (formula_name == "benesipine2")     iter = new DualBenesiPine2Iteration;
+			else
+			{
+				fprintf(stderr, "Unknown formula: %s\nAvailable formulas: hopfbrot, burningship4d, mandelbulb, "
+					"lambdabulb, amazingbox, octopus, mengersponge, cubicbulb, pseudokleinian, "
+					"riemannsphere, mandalay, spheretree, benesipine2\n", formula_name.c_str());
+				return 1;
+			}
 
-		std::vector<IterationFunction *> iter_funcs;
-		//iter_funcs.push_back(oi.clone());
-		//iter_funcs.push_back(pki.clone());
-		//iter_funcs.push_back(mbi.clone());
-		//iter_funcs.push_back(mbti.clone());
-		//iter_funcs.push_back(msi.clone());
-		//iter_funcs.push_back(ai.clone());
-		//iter_funcs.push_back(oi.clone());
-		//iter_funcs.push_back(cbi.clone());
-		//iter_funcs.push_back(dki.clone());
-		//iter_funcs.push_back(bp2.clone());
-		//iter_funcs.push_back(sti.clone());
-		iter_funcs.push_back(lbi.clone());
+			std::vector<IterationFunction *> iter_funcs;
+			iter_funcs.push_back(iter);
+			const std::vector<char> iter_seq = { 0 };
 
-		const std::vector<char> iter_seq = { 0 };
-
-		const int max_iters = 30;
-		GeneralDualDE hybrid(max_iters, iter_funcs, iter_seq);
-
-		hybrid.radius = main_sphere_rad; // For Mandelbulb p8, bounding sphere has approximate radius of 1.2 or so
-		hybrid.step_scale = 0.25; //1;
-		hybrid.mat.albedo = { 0.2f, 0.6f, 0.9f };
-		hybrid.mat.use_fresnel = true;
-
-		scene.objects.push_back(hybrid.clone());
-#endif
+			const int max_iters = 30;
+			GeneralDualDE hybrid(max_iters, iter_funcs, iter_seq);
+			hybrid.radius = main_sphere_rad;
+			hybrid.step_scale = 0.25;
+			hybrid.mat.albedo = { 0.2f, 0.6f, 0.9f };
+			hybrid.mat.use_fresnel = true;
+			scene.objects.push_back(hybrid.clone());
+		}
 		// Test adding sphere lights
 		const int num_sphere_lights = 0;//1 << 5;
 		for (int i = 0; i < num_sphere_lights; ++i)
@@ -236,9 +251,6 @@ int main(int argc, char ** argv)
 	const int image_multi  = mode == mode_animation ? 40 : 80 * 2;
 	const int image_width  = image_multi / image_div * 16;
 	const int image_height = image_multi / image_div * 9;
-	const bool save_normal = false;
-	const bool save_albedo = false;
-
 	std::vector<sRGBPixel> image_LDR(image_width * image_height);
 	RenderOutput output(image_width, image_height);
 
@@ -283,6 +295,23 @@ int main(int argc, char ** argv)
 				if (save_normal) save_tonemapped_buffer("normal", frame, passes, output.normal);
 				if (save_albedo) save_tonemapped_buffer("albedo", frame, passes, output.albedo);
 			}
+
+			// Encode PNG sequences to MP4 using ffmpeg
+			const auto encode_video = [](const char * channel_name)
+			{
+				char cmd[512];
+				snprintf(cmd, sizeof(cmd),
+					"ffmpeg -y -framerate 30 -i %s_frame_%%08d.png -c:v libx264 -pix_fmt yuv420p -crf 18 %s.mp4",
+					channel_name, channel_name);
+				printf("Running: %s\n", cmd);
+				const int ret = system(cmd);
+				if (ret != 0)
+					fprintf(stderr, "Warning: ffmpeg exited with code %d for channel '%s' (is ffmpeg installed?)\n", ret, channel_name);
+			};
+
+			encode_video("beauty");
+			if (save_normal) encode_video("normal");
+			if (save_albedo) encode_video("albedo");
 
 			break;
 		}

--- a/src/formulas/Amazingbox.h
+++ b/src/formulas/Amazingbox.h
@@ -53,7 +53,7 @@ protected:
 		const Dual3r r2 = p_in.x() * p_in.x() + p_in.y() * p_in.y() + p_in.z() * p_in.z();
 		return
 			(r2.v[0] < min_r2) ? p_in * (fix_r2 / min_r2) : // linear inner scaling
-			(r2.v[0] < fix_r2) ? p_in / (r2.v[0] * fix_r2) : // this is the actual sphere inversion
+			(r2.v[0] < fix_r2) ? p_in / (r2 / fix_r2) : // this is the actual sphere inversion
 			p_in;
 	}
 };

--- a/src/formulas/BurningShip4D.h
+++ b/src/formulas/BurningShip4D.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "scene_objects/AnalyticDEObject.h"
+#include "scene_objects/DualDEObject.h"
+
+#include "maths/quat.h"
+
+struct BurningShip4D final : public DualDEObject
+{
+	virtual real getDE(const DualVec3r & p_os, vec3r & normal_os_out) noexcept override final
+	{
+		DualQuat4r c(Dual4r(p_os.x()), Dual4r(p_os.y()), Dual4r(p_os.z()), 0);
+		DualQuat4r w(c);
+
+		for (int i = 0; i < 64; i++)
+		{
+			const real m = length2(w);
+			if (m > 256)
+				break;
+			w = sqr(fabs(w)) + c;
+		}
+
+		return getHybridDEClaude(1, 2, w.v, normal_os_out);
+	}
+
+	virtual SceneObject * clone() const override final
+	{
+		return new BurningShip4D(*this);
+	}
+};

--- a/src/formulas/Hopfbrot.h
+++ b/src/formulas/Hopfbrot.h
@@ -59,7 +59,7 @@ struct Hopfbrot final : public DualDEObject
 	{
 		const int p = 2;
 		real q = 1;
-		DualVec4r c(Dual4r(p_os.x()), Dual4r(p_os.y()), Dual4r(p_os.z()), 0);
+		DualVec4r c(Dual4r(p_os.x()), Dual4r(p_os.y()), Dual4r(p_os.z()), Dual4r(0, 3));
 		DualVec4r w(c);
 
 		for (int i = 0; i < 65536; i++)

--- a/src/formulas/Hopfbrot.h
+++ b/src/formulas/Hopfbrot.h
@@ -57,18 +57,21 @@ struct Hopfbrot final : public DualDEObject
 {
 	virtual real getDE(const DualVec3r & p_os, vec3r & normal_os_out) noexcept override final
 	{
+		const int p = 2;
+		real q = 1;
 		DualVec4r c(Dual4r(p_os.x()), Dual4r(p_os.y()), Dual4r(p_os.z()), 0);
 		DualVec4r w(c);
 
-		for (int i = 0; i < 64; i++)
+		for (int i = 0; i < 65536; i++)
 		{
 			const real m = length2(w);
-			if (m > 256)
-				break;
-			w = hopf(w, 2) + c;
+			if (m > bailout_radius2)
+				return getHybridDEKnighty(p, q, w, normal_os_out);
+			w = hopf(w, p) + c;
+			q *= p;
 		}
-
-		return getHybridDEClaude(1, 2, w, normal_os_out);
+		// fprintf(stderr, "U");
+		return getHybridDEKnighty(p, q, w, normal_os_out);
 	}
 
 	virtual SceneObject * clone() const override final

--- a/src/formulas/Hopfbrot.h
+++ b/src/formulas/Hopfbrot.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "scene_objects/AnalyticDEObject.h"
+#include "scene_objects/DualDEObject.h"
+
+#include "maths/quat.h"
+
+DualVec4r hopf(const DualVec4r &z, int m)
+{
+  auto u = atan2(z.y(), z.x());
+  auto v = atan2(z.w(), z.z());
+  auto t = atan2(z.z() / cos(v), z.x() / cos(u));
+  auto r2 = dot(z, z);
+  u *= m;
+  v *= m;
+  t *= m;
+  if (m != 2) r2 = pow(r2, 0.5f * m);
+  return DualVec4r(cos(u)*cos(t), sin(u)*cos(t), cos(v)*sin(t), sin(v)*sin(t)) * r2;
+}
+
+struct Hopfbrot final : public DualDEObject
+{
+	virtual real getDE(const DualVec3r & p_os, vec3r & normal_os_out) noexcept override final
+	{
+		DualVec4r c(Dual4r(p_os.x()), Dual4r(p_os.y()), Dual4r(p_os.z()), 0);
+		DualVec4r w(c);
+
+		for (int i = 0; i < 64; i++)
+		{
+			const real m = length2(w);
+			if (m > 256)
+				break;
+			w = hopf(w, 2) + c;
+		}
+
+		return getHybridDEClaude(1, 2, w, normal_os_out);
+	}
+
+	virtual SceneObject * clone() const override final
+	{
+		return new Hopfbrot(*this);
+	}
+};

--- a/src/formulas/Hopfbrot.h
+++ b/src/formulas/Hopfbrot.h
@@ -5,17 +5,52 @@
 
 #include "maths/quat.h"
 
+/*
+Mandelbulb, Mandelbrot, Mandelring and Hopfbrot
+Oliver Knill
+<https://doi.org/10.48550/arXiv.2305.17848>
+<https://arxiv.org/abs/2305.17848>
+*/
+
+DualVec4r hopfTrig(const DualVec4r &z, int m)
+{
+	auto u = atan2(z.y(), z.x());
+	auto v = atan2(z.w(), z.z());
+	auto t = atan2(z.z() / cos(v), z.x() / cos(u));
+	auto r2 = dot(z, z);
+	u *= m;
+	v *= m;
+	t *= m;
+	if (m != 2) r2 = pow(r2, real(0.5f * m));
+	return DualVec4r(cos(u)*cos(t), sin(u)*cos(t), cos(v)*sin(t), sin(v)*sin(t)) * r2;
+}
+
+DualVec4r hopfPoly2(const DualVec4r &p)
+{
+	// cos(2 * atan2(y, x)) = (x^2 - y^2) / (x^2 + y^2)
+	// sin(2 * atan2(y, x)) = 2 * x * y / (x^2 + y^2)
+	auto x = p.x(), y = p.y(), z = p.z(), w = p.w();
+	auto x2 = x * x, y2 = y * y, z2 = z * z, w2 = w * w;
+	auto x2y2 = x2 + y2, z2w2 = z2 + w2;
+	auto cos2u = (x2 - y2) / x2y2;
+	auto sin2u = real(2) * x * y / x2y2;
+	auto cos2v = (z2 - w2) / z2w2;
+	auto sin2v = real(2) * z * w / z2w2;
+	auto r2cos2t = x2y2 - z2w2;
+	auto r2sin2t = real(2) * sqrt(x2y2 * z2w2);
+	return DualVec4r(r2cos2t * cos2u, r2cos2t * sin2u, r2sin2t * cos2v, r2sin2t * sin2v);
+}
+
 DualVec4r hopf(const DualVec4r &z, int m)
 {
-  auto u = atan2(z.y(), z.x());
-  auto v = atan2(z.w(), z.z());
-  auto t = atan2(z.z() / cos(v), z.x() / cos(u));
-  auto r2 = dot(z, z);
-  u *= m;
-  v *= m;
-  t *= m;
-  if (m != 2) r2 = pow(r2, real(0.5f * m));
-  return DualVec4r(cos(u)*cos(t), sin(u)*cos(t), cos(v)*sin(t), sin(v)*sin(t)) * r2;
+	if (m == 2)
+	{
+		return hopfPoly2(z);
+	}
+	else
+	{
+		return hopfTrig(z, m);
+	}
 }
 
 struct Hopfbrot final : public DualDEObject

--- a/src/formulas/Hopfbrot.h
+++ b/src/formulas/Hopfbrot.h
@@ -14,7 +14,7 @@ DualVec4r hopf(const DualVec4r &z, int m)
   u *= m;
   v *= m;
   t *= m;
-  if (m != 2) r2 = pow(r2, 0.5f * m);
+  if (m != 2) r2 = pow(r2, real(0.5f * m));
   return DualVec4r(cos(u)*cos(t), sin(u)*cos(t), cos(v)*sin(t), sin(v)*sin(t)) * r2;
 }
 

--- a/src/formulas/Lambdabulb.h
+++ b/src/formulas/Lambdabulb.h
@@ -19,7 +19,7 @@ struct DualLambdabulbIteration final : public IterationFunction
 
 	virtual void init(const DualVec3r & p_0) noexcept override final
 	{
-
+		(void) p_0;
 	}
 
 	virtual void eval(const DualVec3r& p_in, DualVec3r& p_out) const noexcept override final
@@ -54,6 +54,8 @@ protected:
 			cos(phi_p)
 		) * r_p;
 #else
+		(void) power;
+		(void) phase;
 		// polynomial version, hardcoded to power 4
 
 		// wxmaxima: factor(trigexpand(cos(4*atan2(y,x)))) rsp. sin

--- a/src/maths/Dual.h
+++ b/src/maths/Dual.h
@@ -252,14 +252,14 @@ inline constexpr Dual<real_type, vars> fabs(const Dual<real_type, vars> & d) noe
 template <typename real_type, int vars>
 inline constexpr Dual<real_type, vars> clamp(const Dual<real_type, vars> & p, const Dual<real_type, vars> & min_val, const Dual<real_type, vars> & max_val) noexcept
 {
-	return min(max(p, max_val), min_val);
+	return max(min(p, max_val), min_val);
 }
 
 
 template <typename real_type, int vars>
 inline constexpr Dual<real_type, vars> clamp(const Dual<real_type, vars> & p, const real_type min_val, const real_type max_val) noexcept
 {
-	return min(max(p, max_val), min_val);
+	return max(min(p, max_val), min_val);
 }
 
 

--- a/src/maths/Dual.h
+++ b/src/maths/Dual.h
@@ -35,7 +35,17 @@ public:
 	// Copy constructor
 	inline constexpr Dual(const Dual &) noexcept = default;
 
-	inline constexpr const Dual & operator=(const Dual & rhs) noexcept { for (int i = 0; i < vars + 1; ++i) v[i] = rhs.v[i]; return *this; }
+	template <int vars1>
+	inline explicit constexpr Dual(const Dual<real_type, vars1> & a) noexcept
+	{
+		for (int i = 0; i <= vars; ++i)
+			if (i <= vars1)
+				v[i] = a.v[i];
+			else
+				v[i] = 0;
+	}
+
+	inline constexpr Dual & operator=(const Dual & rhs) noexcept = default;
 
 	inline constexpr Dual operator-() const noexcept { Dual r; for (int i = 0; i < vars + 1; ++i) r.v[i] = -v[i]; return r; }
 
@@ -121,6 +131,10 @@ using Dual2d = Dual<double, 2>;
 using Dual3r = Dual<real, 3>;
 using Dual3f = Dual<float, 3>;
 using Dual3d = Dual<double, 3>;
+
+using Dual4r = Dual<real, 4>;
+using Dual4f = Dual<float, 4>;
+using Dual4d = Dual<double, 4>;
 
 
 template <typename real_type, int vars>

--- a/src/maths/quat.h
+++ b/src/maths/quat.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "vec.h"
+
+// quaternion
+
+template <typename real_type>
+struct quat
+{
+	vec<4, real_type> v;
+
+
+	inline quat() { }
+	inline quat(const quat & t) : v(t.v) { }
+	inline quat(const vec<4, real_type> & v) : v(v) { }
+	inline quat(const real_type & x, const real_type & y, const real_type & z, const real_type & w) : v(x, y, z, w) { }
+	inline quat(const real_type & x, const real_type & y, const real_type & z) : v(x, y, z, real_type(0)) { }
+	inline quat(const real_type & x, const real_type & y) : v(x, y, real_type(0)) { }
+	inline quat(const real_type & x) : v(x, real_type(0), real_type(0), real_type(0) ) { }
+
+	inline explicit operator const vec<4, real_type> & () const { return v; }
+
+	inline const quat & operator=(const quat & t) { v = t.v; return *this; }
+
+	inline const real_type & x() const { return v.x(); }
+	inline const real_type & y() const { return v.y(); }
+	inline const real_type & z() const { return v.z(); }
+	inline const real_type & w() const { return v.w(); }
+
+	inline real_type & x() { return v.x(); }
+	inline real_type & y() { return v.y(); }
+	inline real_type & z() { return v.z(); }
+	inline real_type & w() { return v.w(); }
+};
+
+
+template <typename real_type>
+inline quat<real_type> operator+(const quat<real_type> & a, const quat<real_type> & b)
+{
+	return a.v + b.v;
+}
+
+
+template <typename real_type>
+inline quat<real_type> operator-(const quat<real_type> & a, const quat<real_type> & b)
+{
+	return a.v - b.v;
+}
+
+
+template <typename real_type>
+inline quat<real_type> operator-(const quat<real_type> & b)
+{
+	return -b.v;
+}
+
+
+template <typename real_type>
+inline quat<real_type> operator*(const quat<real_type> & a, const real_type & b)
+{
+	return a.v * b;
+}
+
+
+template <typename real_type>
+inline quat<real_type> operator *(const real_type & a, const quat<real_type> & b)
+{
+	return b.v * a;
+}
+
+
+template <typename real_type>
+inline quat<real_type> operator/(const quat<real_type> & a, const real_type & b)
+{
+	return a.v / b;
+}
+
+
+template <typename real_type>
+inline auto length2(const quat<real_type> & a)
+{
+	return length2(a.v);
+}
+
+template <typename real_type>
+inline quat<real_type> fabs(const quat<real_type> & a)
+{
+	return fabs(a.v);
+}
+
+template <typename real_type>
+inline quat<real_type> sqr(const quat<real_type> & a)
+{
+	const real_type x2(sqr(a.x()));
+	const real_type y2(sqr(a.y()));
+	const real_type z2(sqr(a.z()));
+	const real_type w2(sqr(a.w()));
+	return
+	{
+		x2 - y2 - z2 - w2,
+		real_type(2) * a.x() * a.y(),
+		real_type(2) * a.x() * a.z(),
+		real_type(2) * a.x() * a.w()
+	};
+}
+
+
+using quatr = quat<real>;
+using quatf = quat<float>;
+using quatd = quat<double>;
+
+using DualQuat4r = quat<Dual4r>;
+using DualQuat4f = quat<Dual4f>;
+using DualQuat4d = quat<Dual4d>;

--- a/src/maths/real.h
+++ b/src/maths/real.h
@@ -4,7 +4,7 @@
 #include <limits>
 #include <utility>
 
-#define USE_DOUBLE 1
+#define USE_DOUBLE 0
 
 
 

--- a/src/maths/vec.h
+++ b/src/maths/vec.h
@@ -72,6 +72,15 @@ constexpr real_type dot(const vec<n, real_type> & lhs, const vec<n, real_type> &
 	return d;
 }
 
+template<int n, typename real_type>
+constexpr vec<n, real_type> fabs(const vec<n, real_type> & lhs) noexcept
+{
+	vec<n, real_type> r;
+	for (int i = 0; i < n; ++i)
+		 r.e[i] = fabs(lhs.e[i]);
+	return r;
+}
+
 
 // Optimised method for Dual dot product with real-vector RHS
 template<int n, typename real_type>

--- a/src/maths/vec.h
+++ b/src/maths/vec.h
@@ -159,3 +159,7 @@ using vec4i = vec<4, int>;
 using vec4r = vec<4, real>;
 using vec4f = vec<4, float>;
 using vec4d = vec<4, double>;
+
+using DualVec4r = vec<4, Dual4r>;
+using DualVec4f = vec<4, Dual4f>;
+using DualVec4d = vec<4, Dual4d>;

--- a/src/maths/vec.h
+++ b/src/maths/vec.h
@@ -103,8 +103,8 @@ inline real_type length2(const vec<n, real_type> & v) noexcept
 }
 
 
-template<int n, typename real_type>
-constexpr real_type length2(const vec<n, Dual<real_type, 3>> & v) noexcept
+template<int n, int m, typename real_type>
+constexpr real_type length2(const vec<n, Dual<real_type, m>> & v) noexcept
 {
 	real_type d = 0;
 	for (int i = 0; i < n; ++i)

--- a/src/renderer/Renderer.h
+++ b/src/renderer/Renderer.h
@@ -170,7 +170,8 @@ inline void render(const int x, const int y, const int frame, const int pass, co
 	vec3r ray_d = normalise(pixel_v);
 #if 1 // Depth of field
 	const real focal_dist = length(cam_pos - cam_lookat) * 0.65f;
-	const real lens_radius = 0.005f;
+	const real dof = 0.1f; // 1.0f;
+	const real lens_radius = 0.005f * dof;
 
 	// Random point on disc
 	const real lens_r = std::sqrt(wrap1r((real)RadicalInverse(pass, primes[wrap6i(dim)]), hash_random)) * lens_radius;

--- a/src/renderer/Renderer.h
+++ b/src/renderer/Renderer.h
@@ -160,7 +160,7 @@ inline void render(const int x, const int y, const int frame, const int pass, co
 #else
 	const vec3r cam_lookat = { -1.76, 0, -0.025 };
 	const vec3r   world_up = { 0, 0, -1 };
-	const vec3r cam_pos = cam_lookat + vec3r{ cos_t - sin_t, -7 * cos_t, 4 * cos_t + 7 * sin_t } * 0.01;
+	const vec3r cam_pos = cam_lookat + vec3r{ cos_t - sin_t, -7 * cos_t, 4 * cos_t + 7 * sin_t } * 0.02;
 #endif
 	const vec3r cam_forward = normalise(cam_lookat - cam_pos);
 	const vec3r cam_right = normalise(cross(world_up, cam_forward));

--- a/src/renderer/Renderer.h
+++ b/src/renderer/Renderer.h
@@ -157,8 +157,8 @@ inline void render(const int x, const int y, const int frame, const int pass, co
 	const vec3r   world_up = { 0, 1, 0 };
 	const vec3r cam_pos = vec3r{ 4 * cos_t + 10 * sin_t, 5, -10 * cos_t + 4 * sin_t } * 0.25f;
 	const vec3r cam_forward = normalise(cam_lookat - cam_pos);
-	const vec3r cam_right = cross(world_up, cam_forward);
-	const vec3r cam_up = cross(cam_forward, cam_right);
+	const vec3r cam_right = normalise(cross(world_up, cam_forward));
+	const vec3r cam_up = normalise(cross(cam_forward, cam_right));
 
 	const vec3r pixel_x = cam_right * (sensor_width  / xres);
 	const vec3r pixel_y = cam_up   * -(sensor_height / yres);

--- a/src/renderer/Renderer.h
+++ b/src/renderer/Renderer.h
@@ -148,7 +148,8 @@ inline void render(const int x, const int y, const int frame, const int pass, co
 	const real pixel_sample_x = triDist(wrap1r((real)RadicalInverse(pass, primes[wrap6i(dim)]), hash_random));
 	const real pixel_sample_y = triDist(wrap1r((real)RadicalInverse(pass, primes[wrap6i(dim)]), hash_random));
 
-	const real time  = (frames <= 0) ? 0 : two_pi * (frame + triDist(wrap1r((real)RadicalInverse(pass, primes[wrap6i(dim)]), hash_random))) / frames;
+	const real shutter = 0.1f; // 1.0f;
+	const real time  = (frames <= 0) ? 0 : two_pi * (frame + shutter * triDist(wrap1r((real)RadicalInverse(pass, primes[wrap6i(dim)]), hash_random))) / frames;
 	const real cos_t = std::cos(time);
 	const real sin_t = std::sin(time);
 

--- a/src/renderer/Renderer.h
+++ b/src/renderer/Renderer.h
@@ -153,9 +153,15 @@ inline void render(const int x, const int y, const int frame, const int pass, co
 	const real cos_t = std::cos(time);
 	const real sin_t = std::sin(time);
 
+#if 0
 	const vec3r cam_lookat = { 0, -0.125f, 0 };
 	const vec3r   world_up = { 0, 1, 0 };
 	const vec3r cam_pos = vec3r{ 4 * cos_t + 10 * sin_t, 5, -10 * cos_t + 4 * sin_t } * 0.25f;
+#else
+	const vec3r cam_lookat = { -1.76, 0, -0.025 };
+	const vec3r   world_up = { 0, 0, -1 };
+	const vec3r cam_pos = cam_lookat + vec3r{ cos_t - sin_t, -7 * cos_t, 4 * cos_t + 7 * sin_t } * 0.01;
+#endif
 	const vec3r cam_forward = normalise(cam_lookat - cam_pos);
 	const vec3r cam_right = normalise(cross(world_up, cam_forward));
 	const vec3r cam_up = normalise(cross(cam_forward, cam_right));

--- a/src/renderer/Renderer.h
+++ b/src/renderer/Renderer.h
@@ -153,7 +153,7 @@ inline void render(const int x, const int y, const int frame, const int pass, co
 	const real cos_t = std::cos(time);
 	const real sin_t = std::sin(time);
 
-#if 0
+#if 1
 	const vec3r cam_lookat = { 0, -0.125f, 0 };
 	const vec3r   world_up = { 0, 1, 0 };
 	const vec3r cam_pos = vec3r{ 4 * cos_t + 10 * sin_t, 5, -10 * cos_t + 4 * sin_t } * 0.25f;

--- a/src/scene_objects/DualDEObject.h
+++ b/src/scene_objects/DualDEObject.h
@@ -5,7 +5,6 @@
 #include "SceneObject.h"
 
 
-
 // Base class for dual number based distance estimated (DE) objects
 struct DualDEObject : public SceneObject
 {
@@ -184,6 +183,77 @@ struct DualDEObject : public SceneObject
 			// which pollutes everything downstream.
 			// Calling code should deal with it.
 			normal_os_out = normalise(dr);
+			return de;
+		}
+		else
+		{
+			// The derivatives have overflowed to infinity
+			// and then further operations on them yield NaN.
+			// Assuming m is finite it might as well return 0 here.
+			normal_os_out = 0;
+			return 0;
+		}
+	}
+
+	// A DE for hybrids.
+	// Ref: https://mathr.co.uk/de
+	// a:                scale (not used?);
+	// p:                power;
+	// w:                current pos & Jacobian;
+	// normal_os_output: normal vector to output
+	real getHybridDEClaude(const real a, const real p, const DualVec4r & w, vec3r & normal_os_out) const noexcept
+	{
+		// Extract the position vector and Jacobian
+		const vec4r v  = { w.x().v[0], w.y().v[0], w.z().v[0], w.w().v[0] };
+		const vec4r jx = { w.x().v[1], w.y().v[1], w.z().v[1], w.w().v[1] };
+		const vec4r jy = { w.x().v[2], w.y().v[2], w.z().v[2], w.w().v[2] };
+		const vec4r jz = { w.x().v[3], w.y().v[3], w.z().v[3], w.w().v[3] };
+		const vec4r jw = { w.x().v[4], w.y().v[4], w.z().v[4], w.w().v[4] };
+
+		const real len2 = dot(v, v);
+		const real len = std::sqrt(len2);
+		const vec4r u = v * (1 / len); // Normalise p first to avoid overflow in dot products
+
+		// Vector-matrix norm: ||J||_u = |u.J|/|u|
+		// Ref: https://fractalforums.org/fractal-image-gallery/18/burning-ship-distance-estimation/647/msg3207#msg3207
+		const vec4r dr = vec4r
+		{
+			dot(u, jx),
+			dot(u, jy),
+			dot(u, jz),
+			dot(u, jw)
+		};
+		const real len_dr = length(dr);
+
+		// The hybrid DE formula
+		// Ref: https://mathr.co.uk/de
+		const real k = len / len_dr;
+		const real de_base =
+			(p == 1) ? k * std::log(a) :
+			(a == 1) ? k * std::log(p) * std::log(len) : k * (std::log(p) / (p - 1)) * (std::log(a) + (p - 1) * std::log(len));
+
+		// Koebe 1/4 theorem for complex analytic functions says d is
+		// valid up to a factor of 2 either way, we need the lower bound.
+		// Mandelbulb etc are not complex-analytic, but hope for the best...
+		//const real koebe_factor = 0.5f; // Knighty: should not be used IMHO. We already have step_scale.
+
+		// Distance estimate needs a log(power) factor taken out.
+		// Not sure of the justification, but it seems to work better this way,
+		// and it makes it match the other DE modes.
+#if 1
+		const real power_factor = (p == 1) ? 1 : 1 / log(p);
+#else
+		const real power_factor = 1;
+#endif
+		const real de = power_factor * de_base; // * koebe_factor;
+
+		if (std::isfinite(len_dr)) // TODO: this function is probably slow, find a replacement
+		{
+			// At some parts of the fractal, m can become NaN (hairs),
+			// which pollutes everything downstream.
+			// Calling code should deal with it.
+			vec3r dr3 = { dr.e[0], dr.e[1], dr.e[2] };
+			normal_os_out = normalise(dr3);
 			return de;
 		}
 		else

--- a/src/scene_objects/SimpleObjects.h
+++ b/src/scene_objects/SimpleObjects.h
@@ -66,7 +66,7 @@ struct Quad final : public SceneObject
 		return plane_t;
 	}
 
-	virtual vec3r getNormal(const vec3r & p) noexcept override { return n; }
+	virtual vec3r getNormal(const vec3r & p) noexcept override { (void) p; return n; }
 
 	virtual SceneObject * clone() const override final
 	{


### PR DESCRIPTION
## Summary
- Replace compile-time `#if`/`#else` formula toggle with `--formula <name>` flag supporting all 13 formulas at runtime
- Add `--normal` and `--albedo` CLI flags to enable those output channels (previously hardcoded off)
- Encode PNG frame sequences to MP4 via ffmpeg after animation rendering

## Test plan
- [x] Build with `make -j$(nproc)` — no errors or warnings
- [x] `--preview --normal --albedo` produces beauty, normal, and albedo PNGs
- [x] `--formula mandelbulb`, `--formula amazingbox`, `--formula lambdabulb` all render correctly
- [x] Unknown formula name prints available list and exits with code 1
- [x] `--animation --preview --formula mandelbulb` renders 30 frames and encodes `beauty.mp4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)