### PR TITLE
Add AmoserSine formula, interactive UI, and CLI scene loading

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,6 +30,36 @@
             "cwd": "${workspaceFolder}",
             "MIMode": "gdb",
             "preLaunchTask": "CMake: build RelWithDebInfo"
+        },
+        {
+            "name": "(Debug) FractalTracerUI",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Debug/src/FractalTracerUI",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "MIMode": "gdb",
+            "preLaunchTask": "CMake: build Debug"
+        },
+        {
+            "name": "(Release) FractalTracerUI",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Release/src/FractalTracerUI",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "MIMode": "gdb",
+            "preLaunchTask": "CMake: build Release"
+        },
+        {
+            "name": "(RelWithDebInfo) FractalTracerUI",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/RelWithDebInfo/src/FractalTracerUI",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "MIMode": "gdb",
+            "preLaunchTask": "CMake: build RelWithDebInfo"
         }
     ]
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,9 +16,67 @@ include(libs.cmake)
 find_package(OpenMP)
 find_package(Threads)
 
+# CLI batch renderer
 add_executable(FractalTracer demo/main.cpp)
 target_include_directories(FractalTracer PUBLIC .)
 target_link_libraries(FractalTracer
     Threads::Threads OpenMP::OpenMP_CXX
     TracerLib
     )
+
+# Interactive UI (SDL2 + Dear ImGui)
+find_package(SDL2 QUIET)
+if(SDL2_FOUND)
+    # Fetch Dear ImGui
+    include(FetchContent)
+    FetchContent_Declare(
+        imgui
+        GIT_REPOSITORY https://github.com/ocornut/imgui.git
+        GIT_TAG v1.91.8
+    )
+    FetchContent_MakeAvailable(imgui)
+
+    # Build Dear ImGui as a static library
+    add_library(imgui_lib STATIC
+        ${imgui_SOURCE_DIR}/imgui.cpp
+        ${imgui_SOURCE_DIR}/imgui_draw.cpp
+        ${imgui_SOURCE_DIR}/imgui_widgets.cpp
+        ${imgui_SOURCE_DIR}/imgui_tables.cpp
+        ${imgui_SOURCE_DIR}/imgui_demo.cpp
+        ${imgui_SOURCE_DIR}/backends/imgui_impl_sdl2.cpp
+        ${imgui_SOURCE_DIR}/backends/imgui_impl_sdlrenderer2.cpp
+    )
+    target_include_directories(imgui_lib PUBLIC
+        ${imgui_SOURCE_DIR}
+        ${imgui_SOURCE_DIR}/backends
+    )
+    target_link_libraries(imgui_lib PUBLIC SDL2::SDL2)
+
+    # Fetch nlohmann/json
+    FetchContent_Declare(
+        json
+        GIT_REPOSITORY https://github.com/nlohmann/json.git
+        GIT_TAG v3.11.3
+    )
+    FetchContent_MakeAvailable(json)
+
+    add_executable(FractalTracerUI
+        ui/main_ui.cpp
+        ui/RenderController.cpp
+        ui/ImGuiPanels.cpp
+        ui/InteractiveCamera.cpp
+        ui/SceneSerializer.cpp
+        ui/Timeline.cpp
+        ui/AnimationRenderer.cpp
+    )
+    target_include_directories(FractalTracerUI PUBLIC .)
+    target_link_libraries(FractalTracerUI
+        TracerLib
+        Threads::Threads OpenMP::OpenMP_CXX
+        SDL2::SDL2
+        imgui_lib
+        nlohmann_json::nlohmann_json
+    )
+else()
+    message(STATUS "SDL2 not found, skipping FractalTracerUI target")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,12 +16,22 @@ include(libs.cmake)
 find_package(OpenMP)
 find_package(Threads)
 
+# Fetch nlohmann/json (used by both CLI and UI for scene serialization)
+include(FetchContent)
+FetchContent_Declare(
+    json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG v3.11.3
+)
+FetchContent_MakeAvailable(json)
+
 # CLI batch renderer
-add_executable(FractalTracer demo/main.cpp)
+add_executable(FractalTracer demo/main.cpp ui/SceneSerializer.cpp)
 target_include_directories(FractalTracer PUBLIC .)
 target_link_libraries(FractalTracer
     Threads::Threads OpenMP::OpenMP_CXX
     TracerLib
+    nlohmann_json::nlohmann_json
     )
 
 # Interactive UI (SDL2 + Dear ImGui)
@@ -51,14 +61,6 @@ if(SDL2_FOUND)
         ${imgui_SOURCE_DIR}/backends
     )
     target_link_libraries(imgui_lib PUBLIC SDL2::SDL2)
-
-    # Fetch nlohmann/json
-    FetchContent_Declare(
-        json
-        GIT_REPOSITORY https://github.com/nlohmann/json.git
-        GIT_TAG v3.11.3
-    )
-    FetchContent_MakeAvailable(json)
 
     add_executable(FractalTracerUI
         ui/main_ui.cpp

--- a/src/demo/main.cpp
+++ b/src/demo/main.cpp
@@ -30,6 +30,7 @@
 #include "renderer/HDREnvironment.h"
 #include "renderer/Renderer.h"
 #include "renderer/SceneBuilder.h"
+#include "ui/SceneSerializer.h"
 
 
 
@@ -98,6 +99,7 @@ int main(int argc, char ** argv)
 	bool preview = false;
 	bool save_normal = false;
 	bool save_albedo = false;
+	std::string scene_path;
 
 	SceneParams params;
 
@@ -111,7 +113,19 @@ int main(int argc, char ** argv)
 		else if (a == "--albedo")  save_albedo = true;
 		else if (a == "--formula" && arg + 1 < argc) params.fractal.formula_name = argv[++arg];
 		else if (a == "--hdrenv"  && arg + 1 < argc) params.light.hdr_env_path   = argv[++arg];
-		else { fprintf(stderr, "Unknown argument: %s\nUsage: FractalTracer [--formula <name>] [--hdrenv <path>] [--animation] [--preview] [--box] [--normal] [--albedo]\n", argv[arg]); return 1; }
+		else if (a == "--scene"  && arg + 1 < argc)  scene_path = argv[++arg];
+		else { fprintf(stderr, "Unknown argument: %s\nUsage: FractalTracer [--scene <path>] [--formula <name>] [--hdrenv <path>] [--animation] [--preview] [--box] [--normal] [--albedo]\n", argv[arg]); return 1; }
+	}
+
+	// Load scene file if specified (overrides defaults, CLI args can override further)
+	if (!scene_path.empty())
+	{
+		if (!loadScene(scene_path, params))
+		{
+			fprintf(stderr, "Failed to load scene: %s\n", scene_path.c_str());
+			return 1;
+		}
+		printf("Loaded scene: %s\n", scene_path.c_str());
 	}
 
 	// Set formula-specific defaults that differ from the struct defaults
@@ -160,7 +174,7 @@ int main(int argc, char ** argv)
 	Scene scene;
 	if (!buildScene(scene, params.fractal))
 	{
-		fprintf(stderr, "Unknown formula: %s\nAvailable formulas: sphere, amazingbox_mandalay, hopfbrot, burningship4d, mandelbulb, "
+		fprintf(stderr, "Unknown formula: %s\nAvailable formulas: amosersine, sphere, amazingbox_mandalay, hopfbrot, burningship4d, mandelbulb, "
 			"lambdabulb, amazingbox, octopus, mengersponge, cubicbulb, pseudokleinian, "
 			"riemannsphere, mandalay, spheretree, benesipine2\n", params.fractal.formula_name.c_str());
 		return 1;

--- a/src/demo/main.cpp
+++ b/src/demo/main.cpp
@@ -29,25 +29,7 @@
 #include "renderer/Scene.h"
 #include "renderer/HDREnvironment.h"
 #include "renderer/Renderer.h"
-#include "renderer/ColouringFunction.h"
-
-#include "scene_objects/SimpleObjects.h"
-
-#include "formulas/Mandelbulb.h"
-#include "formulas/QuadraticJuliabulb.h"
-#include "formulas/MengerSponge.h"
-#include "formulas/MengerSpongeC.h"
-#include "formulas/Cubicbulb.h"
-#include "formulas/Amazingbox.h"
-#include "formulas/Octopus.h"
-#include "formulas/PseudoKleinian.h"
-#include "formulas/MandalayKIFS.h"
-#include "formulas/BenesiPine2.h"
-#include "formulas/RiemannSphere.h"
-#include "formulas/SphereTree.h"
-#include "formulas/Lambdabulb.h"
-#include "formulas/BurningShip4D.h"
-#include "formulas/Hopfbrot.h"
+#include "renderer/SceneBuilder.h"
 
 
 
@@ -59,11 +41,15 @@ struct sRGBPixel
 };
 
 
-void renderPasses(std::vector<std::thread> & threads, RenderOutput & output, int frame, int base_pass, int num_passes, int frames, Scene & scene, const HDREnvironment * hdr_env) noexcept
+void renderPasses(
+	std::vector<std::thread> & threads, RenderOutput & output,
+	int frame, int base_pass, int num_passes, int frames,
+	const CameraParams & camera, const LightParams & light, const RenderSettings & settings,
+	Scene & scene, const HDREnvironment * hdr_env) noexcept
 {
 	ThreadControl thread_control = { num_passes };
 
-	for (std::thread & t : threads) t = std::thread(renderThreadFunction, &thread_control, &output, frame, base_pass, frames, &scene, hdr_env);
+	for (std::thread & t : threads) t = std::thread(renderThreadFunction, &thread_control, &output, frame, base_pass, frames, &camera, &light, &settings, &scene, hdr_env);
 	for (std::thread & t : threads) t.join();
 }
 
@@ -110,33 +96,55 @@ int main(int argc, char ** argv)
 	// Parse command line arguments
 	enum { mode_progressive, mode_animation } mode = mode_progressive;
 	bool preview = false;
-	bool box = false;
 	bool save_normal = false;
 	bool save_albedo = false;
-	std::string formula_name = "mandalay";
-	std::string hdrenv_path;
+
+	SceneParams params;
+
 	for (int arg = 1; arg < argc; ++arg)
 	{
 		const std::string a = argv[arg];
 		if (a == "--animation") mode = mode_animation;
 		else if (a == "--preview") preview = true;
-		else if (a == "--box")     box = true;
+		else if (a == "--box")     params.fractal.show_box = true;
 		else if (a == "--normal")  save_normal = true;
 		else if (a == "--albedo")  save_albedo = true;
-		else if (a == "--formula" && arg + 1 < argc) formula_name = argv[++arg];
-		else if (a == "--hdrenv"  && arg + 1 < argc) hdrenv_path  = argv[++arg];
+		else if (a == "--formula" && arg + 1 < argc) params.fractal.formula_name = argv[++arg];
+		else if (a == "--hdrenv"  && arg + 1 < argc) params.light.hdr_env_path   = argv[++arg];
 		else { fprintf(stderr, "Unknown argument: %s\nUsage: FractalTracer [--formula <name>] [--hdrenv <path>] [--animation] [--preview] [--box] [--normal] [--albedo]\n", argv[arg]); return 1; }
+	}
+
+	// Set formula-specific defaults that differ from the struct defaults
+	const std::string & formula_name = params.fractal.formula_name;
+	if (formula_name == "hopfbrot")
+	{
+		params.fractal.radius     = 2.0f;
+		params.fractal.step_scale = 0.5f;
+		params.fractal.albedo     = { 0.1f, 0.3f, 0.7f };
+		params.fractal.use_orbit_trap_colouring = false;
+	}
+	else if (formula_name == "burningship4d")
+	{
+		params.fractal.radius = 2.0f;
+		params.fractal.albedo = { 0.1f, 0.3f, 0.7f };
+		params.fractal.use_orbit_trap_colouring = false;
+	}
+	else if (formula_name == "mandelbulb")
+	{
+		params.fractal.radius = 1.25f;
+		params.fractal.albedo = { 0.1f, 0.3f, 0.7f };
+		params.fractal.use_orbit_trap_colouring = false;
 	}
 
 	// Load HDR environment map if specified
 	HDREnvironment hdr_env;
-	if (!hdrenv_path.empty())
+	if (!params.light.hdr_env_path.empty())
 	{
 		int channels;
-		float * hdr_data = stbi_loadf(hdrenv_path.c_str(), &hdr_env.xres, &hdr_env.yres, &channels, 3);
+		float * hdr_data = stbi_loadf(params.light.hdr_env_path.c_str(), &hdr_env.xres, &hdr_env.yres, &channels, 3);
 		if (hdr_data == nullptr)
 		{
-			fprintf(stderr, "Failed to load HDR environment map: %s\n", hdrenv_path.c_str());
+			fprintf(stderr, "Failed to load HDR environment map: %s\n", params.light.hdr_env_path.c_str());
 			return 1;
 		}
 
@@ -145,178 +153,19 @@ int main(int argc, char ** argv)
 			hdr_env.data[i] = { hdr_data[i * 3 + 0], hdr_data[i * 3 + 1], hdr_data[i * 3 + 2] };
 
 		stbi_image_free(hdr_data);
-		printf("Loaded HDR environment map: %s (%d x %d)\n", hdrenv_path.c_str(), hdr_env.xres, hdr_env.yres);
+		printf("Loaded HDR environment map: %s (%d x %d)\n", params.light.hdr_env_path.c_str(), hdr_env.xres, hdr_env.yres);
 	}
 
+	// Build scene from fractal params
 	Scene scene;
+	if (!buildScene(scene, params.fractal))
 	{
-		const real main_sphere_rad = 1.35f;
-
-		Sphere s;
-		s.centre = { 0, 0, 0 };
-		s.radius = main_sphere_rad;
-		s.mat.albedo = { 0.1f, 0.1f, 0.7f };
-		//scene.objects.push_back(s.clone());
-
-		//Sphere s2;
-		//const real bigrad = 128;
-		//s2.centre = { 0, -bigrad - main_sphere_rad, 0 };
-		//s2.radius = bigrad;
-		//s2.mat.albedo = vec3f{ 0.8f, 0.2f, 0.05f } * 1.0f;
-		//s2.mat.use_fresnel = true;
-		//scene.objects.push_back(s2.clone());
-
-		//const real  quad_size = main_sphere_rad;
-		//const vec3r quad_e0 = vec3r{ 0, 0, quad_size } * 2;
-		//const vec3r quad_e1 = vec3r{ quad_size, 0, 0 } * 2;
-		//const vec3r p0 = vec3r(0, -main_sphere_rad, 0) - quad_e0 * 0.5f - quad_e1 * 0.5f;
-		//Quad quad(p0, quad_e0, quad_e1);
-		//quad.mat.albedo = vec3f{ 0.8f, 0.2f, 0.05f } * 1.0f;
-		//quad.mat.use_fresnel = false;
-		//scene.objects.push_back(quad.clone());
-
-
-		if (box)
-		{
-			const real k = main_sphere_rad;
-			Quad q0(vec3r(-k,  k, -k), vec3r(2, 0, 0) * k, vec3r(0, 0, 2) * k); q0.mat.albedo = vec3f(0.7f, 0.7f, 0.7f); q0.mat.use_fresnel = true; scene.objects.push_back(q0.clone()); // top
-			Quad q1(vec3r(-k, -k, -k), vec3r(0, 0, 2) * k, vec3r(2, 0, 0) * k); q1.mat.albedo = vec3f(0.7f, 0.7f, 0.7f); q1.mat.use_fresnel = true; scene.objects.push_back(q1.clone()); // bottom
-			Quad q2(vec3r(-k, -k,  k), vec3r(0, 2, 0) * k, vec3r(2, 0, 0) * k); q2.mat.albedo = vec3f(0.7f, 0.7f, 0.7f); q2.mat.use_fresnel = true; scene.objects.push_back(q2.clone()); // back
-			//Quad q3(vec3r(-k, -k, -k), vec3r(0, 2, 0) * k, vec3r(2, 0, 0) * k); scene.objects.push_back(q3); // front
-			Quad q4(vec3r(-k, -k, -k), vec3r(0, 2, 0) * k, vec3r(0, 0, 2) * k); q4.mat.albedo = vec3f(0.90f, 0.2f, 0.02f); q4.mat.use_fresnel = true; scene.objects.push_back(q4.clone()); // left
-			Quad q5(vec3r( k, -k, -k), vec3r(0, 0, 2) * k, vec3r(0, 2, 0) * k); q5.mat.albedo = vec3f(0.02f, 0.8f, 0.05f); q5.mat.use_fresnel = true; scene.objects.push_back(q5.clone()); // right
-		}
-
-		// Formula dispatch based on --formula flag
-		if (formula_name == "sphere")
-		{
-			Sphere mirror;
-			mirror.centre = { 0, 0, 0 };
-			mirror.radius = main_sphere_rad;
-			mirror.mat.albedo = { 0.9f, 0.9f, 0.9f };
-			mirror.mat.use_fresnel = true;
-			mirror.mat.r0 = 0.95f; // Near-perfect mirror
-			scene.objects.push_back(mirror.clone());
-		}
-		else if (formula_name == "amazingbox_mandalay")
-		{
-			// Hybrid of Amazingbox and MandalayKIFS
-			auto * amazingbox = new DualAmazingboxIteration;
-			amazingbox->scale = -1.77f;
-			amazingbox->fold_limit = 1.0f;
-			amazingbox->min_r2 = 0.25f;
-
-			auto * mandalay = new DualMandalayKIFSIteration;
-			mandalay->scale = 2.8f;
-			mandalay->folding_offset = 1.0f;
-			mandalay->z_tower = 0.35f;
-			mandalay->xy_tower = 0.2f;
-			mandalay->rotate = { 0.12f, 0.08f, 0.0f };
-			mandalay->julia_mode = false;
-
-			std::vector<IterationFunction *> iter_funcs;
-			iter_funcs.push_back(amazingbox);
-			iter_funcs.push_back(mandalay);
-			const std::vector<char> iter_seq = { 0, 0, 1 }; // 2 amazingbox per 1 mandalay
-
-			const int max_iters = 30;
-			GeneralDualDE hybrid(max_iters, iter_funcs, iter_seq);
-			hybrid.radius = main_sphere_rad;
-			hybrid.step_scale = 0.25;
-			hybrid.mat.albedo = { 0.2f, 0.6f, 0.9f };
-			hybrid.mat.use_fresnel = true;
-			hybrid.mat.colouring = new OrbitTrapColouring();
-			scene.objects.push_back(hybrid.clone());
-		}
-		else if (formula_name == "hopfbrot")
-		{
-			Hopfbrot bulb;
-			bulb.radius = 2.0f;
-			bulb.step_scale = 0.5f;
-		    bulb.scene_scale = 2.0f;
-			bulb.mat.albedo = { 0.1f, 0.3f, 0.7f };
-			bulb.mat.use_fresnel = true;
-			scene.objects.push_back(bulb.clone());
-		}
-		else if (formula_name == "burningship4d")
-		{
-			BurningShip4D bulb;
-			bulb.radius = 2.0f;
-			bulb.mat.albedo = { 0.1f, 0.3f, 0.7f };
-			bulb.mat.use_fresnel = true;
-			scene.objects.push_back(bulb.clone());
-		}
-		else if (formula_name == "mandelbulb")
-		{
-			MandelbulbDual bulb;
-			bulb.radius = 1.25f;
-			bulb.mat.albedo = { 0.1f, 0.3f, 0.7f };
-			bulb.mat.use_fresnel = true;
-			scene.objects.push_back(bulb.clone());
-		}
-		else
-		{
-			// IterationFunction-based formulas wrapped in GeneralDualDE
-			IterationFunction * iter = nullptr;
-			if      (formula_name == "lambdabulb")      iter = new DualLambdabulbIteration;
-			else if (formula_name == "amazingbox")      iter = new DualAmazingboxIteration;
-			else if (formula_name == "octopus")         iter = new DualOctopusIteration;
-			else if (formula_name == "mengersponge")    iter = new DualMengerSpongeCIteration;
-			else if (formula_name == "cubicbulb")       iter = new DualCubicbulbIteration;
-			else if (formula_name == "pseudokleinian")  iter = new DualPseudoKleinianIteration;
-			else if (formula_name == "riemannsphere")   iter = new DualRiemannSphereIteration;
-			else if (formula_name == "mandalay")        iter = new DualMandalayKIFSIteration;
-			else if (formula_name == "spheretree")      iter = new DualSphereTreeIteration;
-			else if (formula_name == "benesipine2")     iter = new DualBenesiPine2Iteration;
-			else
-			{
-				fprintf(stderr, "Unknown formula: %s\nAvailable formulas: amazingbox_mandalay, hopfbrot, burningship4d, mandelbulb, "
-					"lambdabulb, amazingbox, octopus, mengersponge, cubicbulb, pseudokleinian, "
-					"riemannsphere, mandalay, spheretree, benesipine2\n", formula_name.c_str());
-				return 1;
-			}
-
-			std::vector<IterationFunction *> iter_funcs;
-			iter_funcs.push_back(iter);
-			const std::vector<char> iter_seq = { 0 };
-
-			const int max_iters = 30;
-			GeneralDualDE hybrid(max_iters, iter_funcs, iter_seq);
-			hybrid.radius = main_sphere_rad;
-			hybrid.step_scale = 0.25;
-			hybrid.mat.albedo = { 0.2f, 0.6f, 0.9f };
-			hybrid.mat.use_fresnel = true;
-			hybrid.mat.r0 = 0.25f; // Shiny surface for strong env map reflections
-			hybrid.mat.colouring = new OrbitTrapColouring();
-			scene.objects.push_back(hybrid.clone());
-		}
-		// Test adding sphere lights
-		const int num_sphere_lights = 0;//1 << 5;
-		for (int i = 0; i < num_sphere_lights; ++i)
-		{
-			const real offset = 0.61803398874989484820458683436564f;
-			const real refl_sample_x = wrap1r(i / (real)num_sphere_lights, offset);
-			//const real refl_sample_x = wrap1r((real)RadicalInverse(i, 3), offset);
-			const real refl_sample_y = wrap1r((real)RadicalInverse(i, 2), offset);
-
-			// Generate uniform point on sphere, see https://mathworld.wolfram.com/SpherePointPicking.html
-			const real a = refl_sample_x * two_pi;
-			const real s = 2 * std::sqrt(std::max(static_cast<real>(0), refl_sample_y * (1 - refl_sample_y)));
-			const vec3r sphere =
-			{
-				std::cos(a) * s,
-				std::sin(a) * s,
-				1 - 2 * refl_sample_y
-			};
-
-			Sphere sp;
-			sp.centre = sphere * 1.0f;
-			sp.radius = 0.05f;
-			sp.mat.albedo = 0.0f;
-			sp.mat.emission = 4;
-			scene.objects.push_back(sp.clone());
-		}
+		fprintf(stderr, "Unknown formula: %s\nAvailable formulas: sphere, amazingbox_mandalay, hopfbrot, burningship4d, mandelbulb, "
+			"lambdabulb, amazingbox, octopus, mengersponge, cubicbulb, pseudokleinian, "
+			"riemannsphere, mandalay, spheretree, benesipine2\n", params.fractal.formula_name.c_str());
+		return 1;
 	}
+
 	const int image_div = preview ? 4 : 1;
 	const int image_multi  = mode == mode_animation ? 40 : 80 * 2;
 	const int image_width  = image_multi / image_div * 16;
@@ -343,16 +192,25 @@ int main(int argc, char ** argv)
 		case mode_animation:
 		{
 			const int frames = preview ? 30 : 30 * 4;
-			const int passes = preview ? 1 : 2 * 3; // 2 * 3 * 5 * 7;
+			const int passes = preview ? 1 : 2 * 3;
 			printf("Rendering %d frames at resolution %d x %d with %d passes\n", frames, image_width, image_height, passes);
 
 			for (int frame = 0; frame < frames; ++frame)
 			{
 				output.clear();
 
+				// Compute camera orbit for this frame
+				const real time  = (frames <= 0) ? 0 : two_pi * frame / frames;
+				const real cos_t = std::cos(time);
+				const real sin_t = std::sin(time);
+				params.camera.position = vec3r{ 4 * cos_t + 10 * sin_t, 5, -10 * cos_t + 4 * sin_t } * 0.25f;
+				params.camera.look_at  = { 0, -0.125f, 0 };
+				params.camera.recompute();
+
 				const auto t1 = std::chrono::steady_clock::now();
 
-				renderPasses(threads, output, frame, 0, passes, frames, scene, &hdr_env);
+				renderPasses(threads, output, frame, 0, passes, frames,
+					params.camera, params.light, params.render, scene, &hdr_env);
 
 				if (print_timing)
 				{
@@ -388,7 +246,12 @@ int main(int argc, char ** argv)
 
 		case mode_progressive:
 		{
-			const int max_passes = 2 * 3 * 5 * 7 * 11; // Set a reasonable max number of passes instead of going forever
+			// Set up static camera for progressive mode
+			params.camera.position = vec3r{ 10, 5, -10 } * 0.25f;
+			params.camera.look_at  = { 0, -0.125f, 0 };
+			params.camera.recompute();
+
+			const int max_passes = params.render.target_passes;
 			printf("Progressive rendering at resolution %d x %d with doubling passes to max %d\n", image_width, image_height, max_passes);
 			output.clear();
 
@@ -400,7 +263,8 @@ int main(int argc, char ** argv)
 
 				// Note that we force num_frames to be zero since we usually don't want motion blur for stills
 				const int num_passes = target_passes - pass;
-				renderPasses(threads, output, 0, pass, num_passes, 0, scene, &hdr_env);
+				renderPasses(threads, output, 0, pass, num_passes, 0,
+					params.camera, params.light, params.render, scene, &hdr_env);
 
 				if (print_timing)
 				{

--- a/src/formulas/AmoserSine.h
+++ b/src/formulas/AmoserSine.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "scene_objects/DualDEObject.h"
+
+
+
+// Amoser Sine formula by amoser
+// 3D extension of the complex sine function, doubly periodic
+struct DualAmoserSineIteration final : public IterationFunction
+{
+	real scale = 2;
+	vec3r julia_c = { 0, 0, 0 };
+	bool julia_mode = false;
+
+private:
+	DualVec3r c;
+
+public:
+	virtual void init(const DualVec3r & p_0) noexcept override final
+	{
+		if (julia_mode)
+			c = DualVec3r(julia_c.x(), julia_c.y(), julia_c.z());
+		else
+			c = p_0;
+	}
+
+	virtual void eval(const DualVec3r & p_in, DualVec3r & p_out) const noexcept override final
+	{
+		p_out = DualVec3r(
+			sin(p_in.x()) * cosh(p_in.y()),
+			cos(p_in.x()) * cos(p_in.z()) * sinh(p_in.y()),
+			sin(p_in.z()) * cosh(p_in.y()));
+
+		p_out = p_out * scale + c;
+	}
+
+	virtual real getPower() const noexcept override final { return 1; }
+
+	virtual IterationFunction * clone() const override final
+	{
+		return new DualAmoserSineIteration(*this);
+	}
+};

--- a/src/formulas/Hopfbrot.h
+++ b/src/formulas/Hopfbrot.h
@@ -12,7 +12,7 @@ Oliver Knill
 <https://arxiv.org/abs/2305.17848>
 */
 
-DualVec4r hopfTrig(const DualVec4r &z, int m)
+inline DualVec4r hopfTrig(const DualVec4r &z, int m)
 {
 	auto u = atan2(z.y(), z.x());
 	auto v = atan2(z.w(), z.z());
@@ -25,7 +25,7 @@ DualVec4r hopfTrig(const DualVec4r &z, int m)
 	return DualVec4r(cos(u)*cos(t), sin(u)*cos(t), cos(v)*sin(t), sin(v)*sin(t)) * r2;
 }
 
-DualVec4r hopfPoly2(const DualVec4r &p)
+inline DualVec4r hopfPoly2(const DualVec4r &p)
 {
 	// cos(2 * atan2(y, x)) = (x^2 - y^2) / (x^2 + y^2)
 	// sin(2 * atan2(y, x)) = 2 * x * y / (x^2 + y^2)
@@ -67,7 +67,7 @@ DualVec4r hopfPoly2(const DualVec4r &p)
 	}
 }
 
-DualVec4r hopf(const DualVec4r &z, int m)
+inline DualVec4r hopf(const DualVec4r &z, int m)
 {
 	if (m == 2)
 	{

--- a/src/libs.cmake
+++ b/src/libs.cmake
@@ -9,12 +9,16 @@ target_sources(TracerLib INTERFACE
     util/stb_image.h
     util/stb_image_write.h
 
+    renderer/CameraParams.h
     renderer/ColouringFunction.h
+    renderer/FractalParams.h
     renderer/HDREnvironment.h
     renderer/Material.h
     renderer/Ray.h
     renderer/Renderer.h
     renderer/Scene.h
+    renderer/SceneBuilder.h
+    renderer/SceneParams.h
 
     scene_objects/AnalyticDEObject.h
     scene_objects/DualDEObject.h
@@ -23,7 +27,10 @@ target_sources(TracerLib INTERFACE
 
     formulas/Amazingbox.h
     formulas/BenesiPine2.h
+    formulas/BurningShip4D.h
     formulas/Cubicbulb.h
+    formulas/Hopfbrot.h
+    formulas/Lambdabulb.h
     formulas/MandalayKIFS.h
     formulas/Mandelbulb.h
     formulas/MengerSponge.h

--- a/src/libs.cmake
+++ b/src/libs.cmake
@@ -35,6 +35,7 @@ target_sources(TracerLib INTERFACE
     formulas/Mandelbulb.h
     formulas/MengerSponge.h
     formulas/MengerSpongeC.h
+    formulas/AmoserSine.h
     formulas/Octopus.h
     formulas/PseudoKleinian.h
     formulas/QuadraticJuliabulb.h

--- a/src/renderer/CameraParams.h
+++ b/src/renderer/CameraParams.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "maths/vec.h"
+
+
+struct CameraParams
+{
+	vec3r position  = { 2.5f, 1.25f, -2.5f };
+	vec3r look_at   = { 0, -0.125f, 0 };
+	vec3r world_up  = { 0, 1, 0 };
+
+	real fov_deg          = 80;
+	real dof_amount       = 0.1f;
+	real lens_radius      = 0.005f;
+	real focal_dist_scale = 0.65f;
+
+	// Precomputed basis vectors (call recompute() after changing position/look_at/world_up)
+	vec3r forward = { 0, 0, 1 };
+	vec3r right   = { 1, 0, 0 };
+	vec3r up      = { 0, 1, 0 };
+
+	void recompute()
+	{
+		forward = normalise(look_at - position);
+		right   = normalise(cross(world_up, forward));
+		up      = normalise(cross(forward, right));
+	}
+};

--- a/src/renderer/FractalParams.h
+++ b/src/renderer/FractalParams.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <string>
+#include "maths/vec.h"
+
+
+struct FractalParams
+{
+	std::string formula_name = "mandalay";
+
+	// Common DE parameters
+	real radius          = 1.35f;
+	real scene_scale     = 1;
+	real step_scale      = 0.25f;
+	real bailout_radius2 = 64;
+	int  max_iters       = 30;
+
+	// Material
+	vec3f albedo   = { 0.2f, 0.6f, 0.9f };
+	vec3f emission = { 0, 0, 0 };
+	bool  use_fresnel = true;
+	float r0 = 0.25f;
+	bool  use_orbit_trap_colouring = true;
+
+	// MandalayKIFS-specific
+	real  mandalay_scale          = 3;
+	real  mandalay_min_r2         = 0;
+	real  mandalay_folding_offset = 1;
+	real  mandalay_z_tower        = 0;
+	real  mandalay_xy_tower       = 0;
+	vec3r mandalay_rotate         = { 0, 0, 0 };
+	vec3r mandalay_julia_c        = { 0, 0, 0 };
+	bool  mandalay_julia_mode     = true;
+
+	// Amazingbox-specific
+	real amazingbox_scale      = -2;
+	real amazingbox_min_r2     = 0.25f;
+	real amazingbox_fix_r2     = 1;
+	real amazingbox_fold_limit = 1;
+	bool amazingbox_julia_mode = false;
+
+	// Hybrid amazingbox_mandalay overrides
+	real hybrid_amazingbox_scale      = -1.77f;
+	real hybrid_amazingbox_fold_limit = 1.0f;
+	real hybrid_amazingbox_min_r2     = 0.25f;
+	real hybrid_mandalay_scale        = 2.8f;
+	real hybrid_mandalay_folding_offset = 1.0f;
+	real hybrid_mandalay_z_tower      = 0.35f;
+	real hybrid_mandalay_xy_tower     = 0.2f;
+	vec3r hybrid_mandalay_rotate      = { 0.12f, 0.08f, 0.0f };
+	bool  hybrid_mandalay_julia_mode  = false;
+
+	// Lambdabulb-specific
+	real  lambdabulb_power = 4;
+	vec3r lambdabulb_c     = { 1.035f, -0.317f, 0.013f };
+
+	// Octopus-specific
+	real octopus_xz_mul    = 1.25f;
+	real octopus_sq_mul    = 1;
+	bool octopus_julia_mode = true;
+
+	// Cubicbulb-specific
+	real  cubicbulb_y_mul      = 3;
+	real  cubicbulb_z_mul      = 3;
+	real  cubicbulb_aux_mul    = 1;
+	vec3r cubicbulb_c          = { -0.5f, -0.5f, -0.25f };
+	bool  cubicbulb_julia_mode = true;
+
+	// BenesiPine2-specific
+	real benesipine2_scale      = 2.5f;
+	real benesipine2_offset     = 0.75f;
+	bool benesipine2_julia_mode = true;
+
+	// MengerSpongeC-specific
+	real  mengersponge_scale        = 3;
+	vec3r mengersponge_scale_centre = { 1.0f, 1.0f, 1.0f };
+
+	// PseudoKleinian-specific
+	real pseudokleinian_mins[4] = { -0.8323f, -0.694f, -0.5045f, 0.8067f };
+	real pseudokleinian_maxs[4] = {  0.8579f,  1.0883f, 0.8937f, 0.9411f };
+
+	// RiemannSphere-specific
+	real riemannsphere_scale   = 1;
+	real riemannsphere_s_shift = 0;
+	real riemannsphere_t_shift = 0;
+	real riemannsphere_x_shift = 1;
+	real riemannsphere_r_shift = -0.25f;
+	real riemannsphere_r_pow   = 2;
+
+	// Sphere (mirror)
+	float sphere_r0 = 0.95f;
+
+	// Hopfbrot-specific
+	real hopfbrot_scene_scale = 2.0f;
+
+	// Show bounding box
+	bool show_box = false;
+};

--- a/src/renderer/FractalParams.h
+++ b/src/renderer/FractalParams.h
@@ -6,7 +6,7 @@
 
 struct FractalParams
 {
-	std::string formula_name = "mandalay";
+	std::string formula_name = "amosersine";
 
 	// Common DE parameters
 	real radius          = 1.35f;
@@ -53,6 +53,11 @@ struct FractalParams
 	// Lambdabulb-specific
 	real  lambdabulb_power = 4;
 	vec3r lambdabulb_c     = { 1.035f, -0.317f, 0.013f };
+
+	// AmoserSine-specific
+	real amosersine_scale = 2;
+	vec3r amosersine_julia_c = { 0, 0, 0 };
+	bool amosersine_julia_mode = false;
 
 	// Octopus-specific
 	real octopus_xz_mul    = 1.25f;

--- a/src/renderer/Renderer.h
+++ b/src/renderer/Renderer.h
@@ -4,17 +4,25 @@
 #include <vector>
 #include <array>
 #include <algorithm>
+#include <cstring>
 
 #include "Scene.h"
 #include "HDREnvironment.h"
+#include "CameraParams.h"
+#include "SceneParams.h"
 
 
 
 constexpr int noise_size = 1 << 8;
-std::array<uint16_t, noise_size * noise_size> noise_data;
+inline std::array<uint16_t, noise_size * noise_size> & getNoiseData()
+{
+	static std::array<uint16_t, noise_size * noise_size> data;
+	return data;
+}
+#define noise_data (getNoiseData())
 
 
-void HilbertFibonacci(const vec2i dx, const vec2i dy, vec2i p, int size, uint64_t & next_val)
+inline void HilbertFibonacci(const vec2i dx, const vec2i dy, vec2i p, int size, uint64_t & next_val)
 {
 	if (size > 1)
 	{
@@ -32,7 +40,7 @@ void HilbertFibonacci(const vec2i dx, const vec2i dy, vec2i p, int size, uint64_
 }
 
 // From PBRT
-double RadicalInverse(int sample, int base) noexcept
+inline double RadicalInverse(int sample, int base) noexcept
 {
 	const double invBase = 1.0 / base;
 
@@ -103,7 +111,7 @@ inline vec2r CauchyDist(const vec2r & u)
 
 struct RenderOutput
 {
-	const int xres, yres;
+	int xres, yres;
 	int passes = 0;
 
 	std::vector<vec3f> beauty;
@@ -116,6 +124,17 @@ struct RenderOutput
 		beauty.resize(xres * yres);
 		normal.resize(xres * yres);
 		albedo.resize(xres * yres);
+	}
+
+	void resize(int new_xres, int new_yres)
+	{
+		xres = new_xres;
+		yres = new_yres;
+		const size_t n = (size_t)xres * yres;
+		beauty.resize(n);
+		normal.resize(n);
+		albedo.resize(n);
+		clear();
 	}
 
 	void clear()
@@ -136,9 +155,13 @@ struct ThreadControl
 };
 
 
-inline void render(const int x, const int y, const int frame, const int pass, const int frames, Scene & scene, RenderOutput & output, const HDREnvironment * hdr_env) noexcept
+inline void render(
+	const int x, const int y,
+	const int frame, const int pass, const int frames,
+	const CameraParams & camera, const LightParams & light, const RenderSettings & settings,
+	Scene & scene, RenderOutput & output, const HDREnvironment * hdr_env) noexcept
 {
-	constexpr int max_bounces = 8;
+	const int max_bounces = settings.max_bounces;
 	constexpr int num_primes  = 6;
 	constexpr static int primes[num_primes] = { 2, 3, 5, 7, 11, 13 };
 	const int xres = output.xres;
@@ -146,8 +169,7 @@ inline void render(const int x, const int y, const int frame, const int pass, co
 	const int pixel_idx = y * xres + x;
 
 	const real aspect_ratio = xres / (real)yres;
-	const real fov_deg = 80.f;
-	const real fov_rad = fov_deg * two_pi / 360; // Convert from degrees to radians
+	const real fov_rad = camera.fov_deg * two_pi / 360;
 	const real sensor_width  = 2 * std::tan(fov_rad / 2);
 	const real sensor_height = sensor_width / aspect_ratio;
 
@@ -166,23 +188,16 @@ inline void render(const int x, const int y, const int frame, const int pass, co
 	const vec2r pixel_offset = CauchyDist(pixel_u);
 #endif
 
-	const real shutter = 0.1f; // 1.0f;
+	const real shutter = 0.1f;
 	const real time  = (frames <= 0) ? 0 : two_pi * (frame + shutter * triDist(wrap1r((real)RadicalInverse(pass, primes[wrap6i(dim)]), hash_random))) / frames;
 	const real cos_t = std::cos(time);
 	const real sin_t = std::sin(time);
+	(void)cos_t; (void)sin_t; // Used only in animation orbit mode
 
-#if 1
-	const vec3r cam_lookat = { 0, -0.125f, 0 };
-	const vec3r   world_up = { 0, 1, 0 };
-	const vec3r cam_pos = vec3r{ 4 * cos_t + 10 * sin_t, 5, -10 * cos_t + 4 * sin_t } * 0.25f;
-#else
-	const vec3r cam_lookat = { -1.76, 0, -0.025 };
-	const vec3r   world_up = { 0, 0, -1 };
-	const vec3r cam_pos = cam_lookat + vec3r{ cos_t - sin_t, -7 * cos_t, 4 * cos_t + 7 * sin_t } * 0.02;
-#endif
-	const vec3r cam_forward = normalise(cam_lookat - cam_pos);
-	const vec3r cam_right = normalise(cross(world_up, cam_forward));
-	const vec3r cam_up = normalise(cross(cam_forward, cam_right));
+	const vec3r & cam_pos     = camera.position;
+	const vec3r & cam_forward = camera.forward;
+	const vec3r & cam_right   = camera.right;
+	const vec3r & cam_up      = camera.up;
 
 	const vec3r pixel_x = cam_right * (sensor_width  / xres);
 	const vec3r pixel_y = cam_up   * -(sensor_height / yres);
@@ -192,23 +207,17 @@ inline void render(const int x, const int y, const int frame, const int pass, co
 
 	vec3r ray_p = cam_pos;
 	vec3r ray_d = normalise(pixel_v);
-#if 1 // Depth of field
-	const real focal_dist = length(cam_pos - cam_lookat) * 0.65f;
-	const real dof = 0.1f; // 1.0f;
-	const real lens_radius = 0.005f * dof;
 
-	// Random point on disc
+	// Depth of field
+	const real focal_dist = length(cam_pos - camera.look_at) * camera.focal_dist_scale;
+	const real lens_radius = camera.lens_radius * camera.dof_amount;
+
 	const real lens_r = std::sqrt(wrap1r((real)RadicalInverse(pass, primes[wrap6i(dim)]), hash_random)) * lens_radius;
 	const real lens_a = two_pi *  wrap1r((real)RadicalInverse(pass, primes[wrap6i(dim)]), hash_random);
 	const vec3r focal_point = ray_p + ray_d * (focal_dist / dot(ray_d, cam_forward));
 
 	ray_p += cam_right * (std::cos(lens_a) * lens_r) + cam_up * (std::sin(lens_a) * lens_r);
 	ray_d = normalise(focal_point - ray_p);
-#endif
-
-	// Useful for debugging
-	//if (x == xres/2 && y == yres/2)
-	//	int a = 9;
 
 	vec3f
 		contribution = 0,
@@ -233,11 +242,9 @@ inline void render(const int x, const int y, const int frame, const int pass, co
 			}
 			else
 			{
-				const vec3f sky_up  = vec3f{  53, 112, 128 } * (1.0f / 255) * 0.75f;
-				const vec3f sky_hz  = vec3f{ 182, 175, 157 } * (1.0f / 255) * 0.8f;
 				const float height  = 1 - std::max(0.0f, (float)ray.d.y());
 				const float height2 = height * height;
-				sky = sky_up + (sky_hz - sky_up) * height2 * height2;
+				sky = light.sky_up_colour + (light.sky_hz_colour - light.sky_up_colour) * height2 * height2;
 			}
 			contribution += throughput * sky;
 			break;
@@ -296,9 +303,7 @@ inline void render(const int x, const int y, const int frame, const int pass, co
 		// Do direct lighting from a fixed point light
 		if (!sample_specular)
 		{
-			// Compute vector from intersection point to light
-			const vec3r light_pos = { 8, 12, -6 };
-			const vec3r light_vec = light_pos - hit_p;
+			const vec3r light_vec = light.light_pos - hit_p;
 
 			// Compute reflected light (simple diffuse / Lambertian) with 1/distance^2 falloff
 			const real n_dot_l = dot(normal, light_vec);
@@ -308,7 +313,7 @@ inline void render(const int x, const int y, const int frame, const int pass, co
 				const real  light_len = std::sqrt(light_ln2);
 				const vec3r light_dir = light_vec * (1 / light_len);
 
-				const vec3f refl_colour = albedo * (float)n_dot_l / (float)(light_ln2 * light_len) * 720; // 420;
+				const vec3f refl_colour = albedo * (float)n_dot_l / (float)(light_ln2 * light_len) * (float)light.light_intensity;
 
 				// Trace shadow ray from the hit point towards the light
 				const Ray shadow_ray = { hit_p, light_dir };
@@ -377,10 +382,12 @@ inline void render(const int x, const int y, const int frame, const int pass, co
 }
 
 
-void renderThreadFunction(
+inline void renderThreadFunction(
 	ThreadControl * const thread_control,
 	RenderOutput * const output,
-	const int frame, const int base_pass, const int frames, const Scene * const scene_,
+	const int frame, const int base_pass, const int frames,
+	const CameraParams * const camera, const LightParams * const light, const RenderSettings * const settings,
+	const Scene * const scene_,
 	const HDREnvironment * const hdr_env) noexcept
 {
 	const int xres = output->xres;
@@ -413,6 +420,6 @@ void renderThreadFunction(
 
 		for (int y = bucket_y0; y < bucket_y1; ++y)
 		for (int x = bucket_x0; x < bucket_x1; ++x)
-			render(x, y, frame, base_pass + sub_pass, frames, scene, *output, hdr_env);
+			render(x, y, frame, base_pass + sub_pass, frames, *camera, *light, *settings, scene, *output, hdr_env);
 	}
 }

--- a/src/renderer/SceneBuilder.h
+++ b/src/renderer/SceneBuilder.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#include "renderer/Scene.h"
+#include "renderer/SceneParams.h"
+#include "renderer/ColouringFunction.h"
+#include "scene_objects/SimpleObjects.h"
+#include "scene_objects/DualDEObject.h"
+
+#include "formulas/Mandelbulb.h"
+#include "formulas/QuadraticJuliabulb.h"
+#include "formulas/MengerSponge.h"
+#include "formulas/MengerSpongeC.h"
+#include "formulas/Cubicbulb.h"
+#include "formulas/Amazingbox.h"
+#include "formulas/Octopus.h"
+#include "formulas/PseudoKleinian.h"
+#include "formulas/MandalayKIFS.h"
+#include "formulas/BenesiPine2.h"
+#include "formulas/RiemannSphere.h"
+#include "formulas/SphereTree.h"
+#include "formulas/Lambdabulb.h"
+#include "formulas/BurningShip4D.h"
+#include "formulas/Hopfbrot.h"
+
+
+// Build a Scene from FractalParams
+// Returns false if formula_name is unknown
+inline bool buildScene(Scene & scene, const FractalParams & fp)
+{
+	// Clear existing objects
+	for (SceneObject * o : scene.objects) delete o;
+	scene.objects.clear();
+
+	// Optional bounding box
+	if (fp.show_box)
+	{
+		const real k = fp.radius;
+		Quad q0(vec3r(-k,  k, -k), vec3r(2, 0, 0) * k, vec3r(0, 0, 2) * k); q0.mat.albedo = vec3f(0.7f, 0.7f, 0.7f); q0.mat.use_fresnel = true; scene.objects.push_back(q0.clone());
+		Quad q1(vec3r(-k, -k, -k), vec3r(0, 0, 2) * k, vec3r(2, 0, 0) * k); q1.mat.albedo = vec3f(0.7f, 0.7f, 0.7f); q1.mat.use_fresnel = true; scene.objects.push_back(q1.clone());
+		Quad q2(vec3r(-k, -k,  k), vec3r(0, 2, 0) * k, vec3r(2, 0, 0) * k); q2.mat.albedo = vec3f(0.7f, 0.7f, 0.7f); q2.mat.use_fresnel = true; scene.objects.push_back(q2.clone());
+		Quad q4(vec3r(-k, -k, -k), vec3r(0, 2, 0) * k, vec3r(0, 0, 2) * k); q4.mat.albedo = vec3f(0.90f, 0.2f, 0.02f); q4.mat.use_fresnel = true; scene.objects.push_back(q4.clone());
+		Quad q5(vec3r( k, -k, -k), vec3r(0, 0, 2) * k, vec3r(0, 2, 0) * k); q5.mat.albedo = vec3f(0.02f, 0.8f, 0.05f); q5.mat.use_fresnel = true; scene.objects.push_back(q5.clone());
+	}
+
+	const std::string & name = fp.formula_name;
+
+	if (name == "sphere")
+	{
+		Sphere mirror;
+		mirror.centre = { 0, 0, 0 };
+		mirror.radius = fp.radius;
+		mirror.mat.albedo = { 0.9f, 0.9f, 0.9f };
+		mirror.mat.use_fresnel = true;
+		mirror.mat.r0 = fp.sphere_r0;
+		scene.objects.push_back(mirror.clone());
+	}
+	else if (name == "amazingbox_mandalay")
+	{
+		auto * amazingbox = new DualAmazingboxIteration;
+		amazingbox->scale      = fp.hybrid_amazingbox_scale;
+		amazingbox->fold_limit = fp.hybrid_amazingbox_fold_limit;
+		amazingbox->min_r2     = fp.hybrid_amazingbox_min_r2;
+
+		auto * mandalay = new DualMandalayKIFSIteration;
+		mandalay->scale          = fp.hybrid_mandalay_scale;
+		mandalay->folding_offset = fp.hybrid_mandalay_folding_offset;
+		mandalay->z_tower        = fp.hybrid_mandalay_z_tower;
+		mandalay->xy_tower       = fp.hybrid_mandalay_xy_tower;
+		mandalay->rotate         = fp.hybrid_mandalay_rotate;
+		mandalay->julia_mode     = fp.hybrid_mandalay_julia_mode;
+
+		std::vector<IterationFunction *> iter_funcs;
+		iter_funcs.push_back(amazingbox);
+		iter_funcs.push_back(mandalay);
+		const std::vector<char> iter_seq = { 0, 0, 1 };
+
+		GeneralDualDE hybrid(fp.max_iters, iter_funcs, iter_seq);
+		hybrid.radius     = fp.radius;
+		hybrid.step_scale = fp.step_scale;
+		hybrid.mat.albedo      = fp.albedo;
+		hybrid.mat.use_fresnel = fp.use_fresnel;
+		if (fp.use_orbit_trap_colouring) hybrid.mat.colouring = new OrbitTrapColouring();
+		scene.objects.push_back(hybrid.clone());
+	}
+	else if (name == "hopfbrot")
+	{
+		Hopfbrot bulb;
+		bulb.radius      = fp.radius;
+		bulb.step_scale  = fp.step_scale;
+		bulb.scene_scale = fp.hopfbrot_scene_scale;
+		bulb.mat.albedo      = fp.albedo;
+		bulb.mat.use_fresnel = fp.use_fresnel;
+		if (fp.use_orbit_trap_colouring) bulb.mat.colouring = new OrbitTrapColouring();
+		scene.objects.push_back(bulb.clone());
+	}
+	else if (name == "burningship4d")
+	{
+		BurningShip4D bulb;
+		bulb.radius = fp.radius;
+		bulb.mat.albedo      = fp.albedo;
+		bulb.mat.use_fresnel = fp.use_fresnel;
+		if (fp.use_orbit_trap_colouring) bulb.mat.colouring = new OrbitTrapColouring();
+		scene.objects.push_back(bulb.clone());
+	}
+	else if (name == "mandelbulb")
+	{
+		MandelbulbDual bulb;
+		bulb.radius = fp.radius;
+		bulb.mat.albedo      = fp.albedo;
+		bulb.mat.use_fresnel = fp.use_fresnel;
+		if (fp.use_orbit_trap_colouring) bulb.mat.colouring = new OrbitTrapColouring();
+		scene.objects.push_back(bulb.clone());
+	}
+	else
+	{
+		// IterationFunction-based formulas wrapped in GeneralDualDE
+		IterationFunction * iter = nullptr;
+
+		if      (name == "lambdabulb")     { auto * p = new DualLambdabulbIteration;        p->power = fp.lambdabulb_power; p->c = DualVec3r(fp.lambdabulb_c.x(), fp.lambdabulb_c.y(), fp.lambdabulb_c.z()); iter = p; }
+		else if (name == "amazingbox")     { auto * p = new DualAmazingboxIteration;        p->scale = fp.amazingbox_scale; p->min_r2 = fp.amazingbox_min_r2; p->fix_r2 = fp.amazingbox_fix_r2; p->fold_limit = fp.amazingbox_fold_limit; p->julia_mode = fp.amazingbox_julia_mode; iter = p; }
+		else if (name == "octopus")        { auto * p = new DualOctopusIteration;           p->xz_mul = fp.octopus_xz_mul; p->sq_mul = fp.octopus_sq_mul; p->julia_mode = fp.octopus_julia_mode; iter = p; }
+		else if (name == "mengersponge")   { auto * p = new DualMengerSpongeCIteration;     p->scale = fp.mengersponge_scale; p->scale_centre = fp.mengersponge_scale_centre; iter = p; }
+		else if (name == "cubicbulb")      { auto * p = new DualCubicbulbIteration;         p->y_mul = fp.cubicbulb_y_mul; p->z_mul = fp.cubicbulb_z_mul; p->aux_mul = fp.cubicbulb_aux_mul; p->c = DualVec3r(fp.cubicbulb_c.x(), fp.cubicbulb_c.y(), fp.cubicbulb_c.z()); p->julia_mode = fp.cubicbulb_julia_mode; iter = p; }
+		else if (name == "pseudokleinian") { auto * p = new DualPseudoKleinianIteration;    for (int i = 0; i < 4; i++) { p->mins[i] = fp.pseudokleinian_mins[i]; p->maxs[i] = fp.pseudokleinian_maxs[i]; } iter = p; }
+		else if (name == "riemannsphere")  { auto * p = new DualRiemannSphereIteration;     p->scale = fp.riemannsphere_scale; p->s_shift = fp.riemannsphere_s_shift; p->t_shift = fp.riemannsphere_t_shift; p->x_shift = fp.riemannsphere_x_shift; p->r_shift = fp.riemannsphere_r_shift; p->r_pow = fp.riemannsphere_r_pow; iter = p; }
+		else if (name == "mandalay")       { auto * p = new DualMandalayKIFSIteration;      p->scale = fp.mandalay_scale; p->min_r2 = fp.mandalay_min_r2; p->folding_offset = fp.mandalay_folding_offset; p->z_tower = fp.mandalay_z_tower; p->xy_tower = fp.mandalay_xy_tower; p->rotate = fp.mandalay_rotate; p->julia_c = fp.mandalay_julia_c; p->julia_mode = fp.mandalay_julia_mode; iter = p; }
+		else if (name == "spheretree")     { iter = new DualSphereTreeIteration; }
+		else if (name == "benesipine2")    { auto * p = new DualBenesiPine2Iteration;       p->scale = fp.benesipine2_scale; p->offset = fp.benesipine2_offset; p->julia_mode = fp.benesipine2_julia_mode; iter = p; }
+		else
+			return false; // Unknown formula
+
+		std::vector<IterationFunction *> iter_funcs;
+		iter_funcs.push_back(iter);
+		const std::vector<char> iter_seq = { 0 };
+
+		GeneralDualDE hybrid(fp.max_iters, iter_funcs, iter_seq);
+		hybrid.radius         = fp.radius;
+		hybrid.step_scale     = fp.step_scale;
+		hybrid.bailout_radius2 = fp.bailout_radius2;
+		hybrid.mat.albedo      = fp.albedo;
+		hybrid.mat.emission    = fp.emission;
+		hybrid.mat.use_fresnel = fp.use_fresnel;
+		hybrid.mat.r0          = fp.r0;
+		if (fp.use_orbit_trap_colouring) hybrid.mat.colouring = new OrbitTrapColouring();
+		scene.objects.push_back(hybrid.clone());
+	}
+
+	return true;
+}

--- a/src/renderer/SceneBuilder.h
+++ b/src/renderer/SceneBuilder.h
@@ -13,6 +13,7 @@
 #include "formulas/Cubicbulb.h"
 #include "formulas/Amazingbox.h"
 #include "formulas/Octopus.h"
+#include "formulas/AmoserSine.h"
 #include "formulas/PseudoKleinian.h"
 #include "formulas/MandalayKIFS.h"
 #include "formulas/BenesiPine2.h"
@@ -125,6 +126,7 @@ inline bool buildScene(Scene & scene, const FractalParams & fp)
 		else if (name == "riemannsphere")  { auto * p = new DualRiemannSphereIteration;     p->scale = fp.riemannsphere_scale; p->s_shift = fp.riemannsphere_s_shift; p->t_shift = fp.riemannsphere_t_shift; p->x_shift = fp.riemannsphere_x_shift; p->r_shift = fp.riemannsphere_r_shift; p->r_pow = fp.riemannsphere_r_pow; iter = p; }
 		else if (name == "mandalay")       { auto * p = new DualMandalayKIFSIteration;      p->scale = fp.mandalay_scale; p->min_r2 = fp.mandalay_min_r2; p->folding_offset = fp.mandalay_folding_offset; p->z_tower = fp.mandalay_z_tower; p->xy_tower = fp.mandalay_xy_tower; p->rotate = fp.mandalay_rotate; p->julia_c = fp.mandalay_julia_c; p->julia_mode = fp.mandalay_julia_mode; iter = p; }
 		else if (name == "spheretree")     { iter = new DualSphereTreeIteration; }
+		else if (name == "amosersine")     { auto * p = new DualAmoserSineIteration;        p->scale = fp.amosersine_scale; p->julia_c = fp.amosersine_julia_c; p->julia_mode = fp.amosersine_julia_mode; iter = p; }
 		else if (name == "benesipine2")    { auto * p = new DualBenesiPine2Iteration;       p->scale = fp.benesipine2_scale; p->offset = fp.benesipine2_offset; p->julia_mode = fp.benesipine2_julia_mode; iter = p; }
 		else
 			return false; // Unknown formula

--- a/src/renderer/SceneParams.h
+++ b/src/renderer/SceneParams.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "maths/vec.h"
+#include "renderer/CameraParams.h"
+#include "renderer/FractalParams.h"
+
+
+struct LightParams
+{
+	vec3r light_pos       = { 8, 12, -6 };
+	real  light_intensity = 720;
+
+	// Procedural sky colours
+	vec3f sky_up_colour = vec3f{  53, 112, 128 } * (1.0f / 255) * 0.75f;
+	vec3f sky_hz_colour = vec3f{ 182, 175, 157 } * (1.0f / 255) * 0.8f;
+
+	// HDR environment map path (empty = use procedural sky)
+	std::string hdr_env_path;
+};
+
+
+struct RenderSettings
+{
+	int max_bounces   = 8;
+	int target_passes = 2310; // 2*3*5*7*11
+	int resolution_x  = 1280;
+	int resolution_y  = 720;
+};
+
+
+struct SceneParams
+{
+	CameraParams   camera;
+	FractalParams  fractal;
+	LightParams    light;
+	RenderSettings render;
+};

--- a/src/renderer/SceneParams.h
+++ b/src/renderer/SceneParams.h
@@ -21,10 +21,11 @@ struct LightParams
 
 struct RenderSettings
 {
-	int max_bounces   = 8;
-	int target_passes = 2310; // 2*3*5*7*11
-	int resolution_x  = 1280;
-	int resolution_y  = 720;
+	int max_bounces     = 8;
+	int target_passes   = 2310; // 2*3*5*7*11
+	int resolution_x    = 1280;
+	int resolution_y    = 720;
+	int preview_divisor = 32;   // Sub-resolution divisor for interactive preview
 };
 
 

--- a/src/ui/AnimationRenderer.cpp
+++ b/src/ui/AnimationRenderer.cpp
@@ -1,0 +1,258 @@
+#define _CRT_SECURE_NO_WARNINGS
+
+#include "AnimationRenderer.h"
+
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "../util/stb_image_write.h"
+
+#include <cmath>
+#include <cstdio>
+#include <algorithm>
+#include <chrono>
+#include <sys/stat.h>
+
+
+AnimationRenderer::~AnimationRenderer()
+{
+	cancel();
+}
+
+
+void AnimationRenderer::start(const Timeline & timeline, const SceneParams & base_params,
+	const AnimationSettings & settings, int num_threads)
+{
+	if (rendering.load()) return;
+
+	cancel_requested = false;
+	finished = false;
+	current_frame = 0;
+	current_pass = 0;
+
+	const int fps = timeline.fps;
+	const int frames = (int)(timeline.duration_seconds * fps);
+	total_frames = frames;
+	total_passes = settings.target_spp;
+
+	{
+		std::lock_guard<std::mutex> lock(status_mutex);
+		status_message = "Starting animation render...";
+	}
+
+	rendering = true;
+	if (render_thread.joinable())
+		render_thread.join();
+	render_thread = std::thread(&AnimationRenderer::renderFunc, this,
+		timeline, base_params, settings, num_threads);
+}
+
+
+void AnimationRenderer::cancel()
+{
+	cancel_requested = true;
+	if (render_thread.joinable())
+		render_thread.join();
+}
+
+
+std::string AnimationRenderer::getStatusMessage() const
+{
+	std::lock_guard<std::mutex> lock(status_mutex);
+	return status_message;
+}
+
+
+struct sRGBPixelAnim { uint8_t r, g, b; };
+
+static void tonemapFrame(std::vector<sRGBPixelAnim> & image_LDR,
+	const std::vector<vec3f> & beauty, int passes, int xres, int yres)
+{
+	const auto sRGB = [](float u) -> float
+	{
+		return (u <= 0.0031308f) ? 12.92f * u : 1.055f * std::pow(u, 0.416667f) - 0.055f;
+	};
+	const float scale = 1.0f / std::max(1, passes);
+
+	image_LDR.resize(xres * yres);
+	for (int y = 0; y < yres; y++)
+	for (int x = 0; x < xres; x++)
+	{
+		const int i = y * xres + x;
+		const vec3f c = beauty[i];
+		image_LDR[i] =
+		{
+			(uint8_t)std::max(0.0f, std::min(255.0f, sRGB(c.x() * scale) * 256)),
+			(uint8_t)std::max(0.0f, std::min(255.0f, sRGB(c.y() * scale) * 256)),
+			(uint8_t)std::max(0.0f, std::min(255.0f, sRGB(c.z() * scale) * 256))
+		};
+	}
+}
+
+
+void AnimationRenderer::renderFunc(Timeline timeline, SceneParams base_params,
+	AnimationSettings settings, int num_threads)
+{
+	const int fps = timeline.fps;
+	const int frames = (int)(timeline.duration_seconds * fps);
+	const int spp = settings.target_spp;
+	const int xres = settings.output_xres;
+	const int yres = settings.output_yres;
+
+	// Create output directory
+#ifdef _WIN32
+	_mkdir(settings.output_dir.c_str());
+#else
+	mkdir(settings.output_dir.c_str(), 0755);
+#endif
+
+	// Init noise table
+	{
+		uint64_t v = 0;
+		HilbertFibonacci(vec2i(1, 0), vec2i(0, 1), 0, noise_size, v);
+	}
+
+	RenderOutput output(xres, yres);
+	std::vector<std::thread> workers(num_threads);
+	std::vector<sRGBPixelAnim> image_LDR;
+
+	// Load HDR environment if needed
+	HDREnvironment hdr_env;
+
+	for (int frame = 0; frame < frames; ++frame)
+	{
+		if (cancel_requested.load()) break;
+
+		current_frame = frame;
+		current_pass = 0;
+
+		// Evaluate timeline at this frame's time
+		const float frame_time = (float)frame / fps;
+		SceneParams frame_params = base_params;
+
+		if (!timeline.keyframes.empty())
+		{
+			SceneParams interpolated = timeline.evaluate(frame_time);
+			frame_params.camera = interpolated.camera;
+			frame_params.fractal = interpolated.fractal;
+			frame_params.light = interpolated.light;
+		}
+
+		frame_params.camera.recompute();
+
+		// Build scene for this frame
+		Scene scene;
+		if (!buildScene(scene, frame_params.fractal))
+		{
+			std::lock_guard<std::mutex> lock(status_mutex);
+			status_message = "Error: failed to build scene for frame " + std::to_string(frame);
+			rendering = false;
+			return;
+		}
+
+		// Clear output for new frame
+		output.clear();
+
+		const auto frame_start = std::chrono::steady_clock::now();
+
+		// Render all passes for this frame
+		for (int pass = 0; pass < spp; ++pass)
+		{
+			if (cancel_requested.load()) break;
+
+			current_pass = pass;
+
+			ThreadControl thread_control = { 1 };
+
+			for (std::thread & t : workers)
+			{
+				t = std::thread([&, pass]()
+				{
+					Scene local_scene(scene);
+
+					constexpr int bucket_size = 32;
+					const int x_buckets = (xres + bucket_size - 1) / bucket_size;
+					const int y_buckets = (yres + bucket_size - 1) / bucket_size;
+					const int num_buckets = x_buckets * y_buckets;
+
+					while (true)
+					{
+						if (cancel_requested.load()) break;
+
+						const int bucket = thread_control.next_bucket.fetch_add(1);
+						if (bucket >= num_buckets) break;
+
+						const int bucket_y = bucket / x_buckets;
+						const int bucket_x = bucket - x_buckets * bucket_y;
+						const int x0 = bucket_x * bucket_size, x1 = std::min(x0 + bucket_size, xres);
+						const int y0 = bucket_y * bucket_size, y1 = std::min(y0 + bucket_size, yres);
+
+						for (int y = y0; y < y1; ++y)
+						for (int x = x0; x < x1; ++x)
+							render(x, y, frame, pass, frames, frame_params.camera, frame_params.light,
+								frame_params.render, local_scene, output, &hdr_env);
+					}
+				});
+			}
+
+			for (std::thread & t : workers)
+				t.join();
+		}
+
+		if (cancel_requested.load()) break;
+
+		// Tonemap and save PNG
+		tonemapFrame(image_LDR, output.beauty, spp, xres, yres);
+
+		char filename[512];
+		snprintf(filename, sizeof(filename), "%s/frame_%08d.png",
+			settings.output_dir.c_str(), frame);
+		stbi_write_png(filename, xres, yres, 3, image_LDR.data(), xres * 3);
+
+		const auto frame_end = std::chrono::steady_clock::now();
+		const double frame_secs = std::chrono::duration<double>(frame_end - frame_start).count();
+
+		{
+			std::lock_guard<std::mutex> lock(status_mutex);
+			char msg[256];
+			snprintf(msg, sizeof(msg), "Frame %d/%d rendered in %.1f s", frame + 1, frames, frame_secs);
+			status_message = msg;
+		}
+	}
+
+	if (cancel_requested.load())
+	{
+		std::lock_guard<std::mutex> lock(status_mutex);
+		status_message = "Animation render cancelled.";
+		rendering = false;
+		return;
+	}
+
+	// Encode to MP4 with ffmpeg
+	if (settings.encode_mp4)
+	{
+		{
+			std::lock_guard<std::mutex> lock(status_mutex);
+			status_message = "Encoding MP4 with ffmpeg...";
+		}
+
+		char cmd[1024];
+		snprintf(cmd, sizeof(cmd),
+			"ffmpeg -y -framerate %d -i %s/frame_%%08d.png -c:v libx264 -pix_fmt yuv420p -crf 18 %s/animation.mp4",
+			fps, settings.output_dir.c_str(), settings.output_dir.c_str());
+
+		const int ret = system(cmd);
+
+		std::lock_guard<std::mutex> lock(status_mutex);
+		if (ret == 0)
+			status_message = "Animation complete! Saved to " + settings.output_dir + "/animation.mp4";
+		else
+			status_message = "Frames saved to " + settings.output_dir + "/ (ffmpeg encoding failed, is ffmpeg installed?)";
+	}
+	else
+	{
+		std::lock_guard<std::mutex> lock(status_mutex);
+		status_message = "Animation complete! Frames saved to " + settings.output_dir + "/";
+	}
+
+	finished = true;
+	rendering = false;
+}

--- a/src/ui/AnimationRenderer.h
+++ b/src/ui/AnimationRenderer.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <vector>
+#include <string>
+
+#include "renderer/Renderer.h"
+#include "renderer/SceneParams.h"
+#include "renderer/SceneBuilder.h"
+#include "Timeline.h"
+
+
+struct AnimationSettings
+{
+	int target_spp = 64;
+	int output_xres = 1920;
+	int output_yres = 1080;
+	std::string output_dir = "anim_output";
+	bool encode_mp4 = true;
+};
+
+
+struct AnimationRenderer
+{
+	// Start rendering animation in background
+	void start(const Timeline & timeline, const SceneParams & base_params,
+		const AnimationSettings & settings, int num_threads);
+
+	// Cancel rendering
+	void cancel();
+
+	// Is rendering in progress?
+	bool isRendering() const { return rendering.load(); }
+
+	// Progress info
+	int getCurrentFrame() const { return current_frame.load(); }
+	int getTotalFrames() const { return total_frames.load(); }
+	int getCurrentPass() const { return current_pass.load(); }
+	int getTotalPasses() const { return total_passes.load(); }
+	std::string getStatusMessage() const;
+
+	// Did rendering complete successfully?
+	bool isFinished() const { return finished.load(); }
+
+	~AnimationRenderer();
+
+private:
+	void renderFunc(Timeline timeline, SceneParams base_params,
+		AnimationSettings settings, int num_threads);
+
+	std::thread render_thread;
+	std::atomic<bool> rendering{false};
+	std::atomic<bool> cancel_requested{false};
+	std::atomic<bool> finished{false};
+	std::atomic<int> current_frame{0};
+	std::atomic<int> total_frames{0};
+	std::atomic<int> current_pass{0};
+	std::atomic<int> total_passes{0};
+	mutable std::mutex status_mutex;
+	std::string status_message;
+};

--- a/src/ui/ImGuiPanels.cpp
+++ b/src/ui/ImGuiPanels.cpp
@@ -255,8 +255,9 @@ bool drawRenderSettingsPanel(RenderSettings & settings)
 }
 
 
-void drawStatsOverlay(int passes, int xres, int yres, float fps)
+bool drawStatsOverlay(int passes, int xres, int yres, float fps)
 {
+	bool refresh = false;
 	ImGui::SetNextWindowPos(ImVec2(10, 10), ImGuiCond_Always);
 	ImGui::SetNextWindowBgAlpha(0.5f);
 	if (ImGui::Begin("Stats", nullptr,
@@ -267,8 +268,11 @@ void drawStatsOverlay(int passes, int xres, int yres, float fps)
 		ImGui::Text("Resolution: %d x %d", xres, yres);
 		ImGui::Text("Passes: %d", passes);
 		ImGui::Text("FPS: %.1f", fps);
+		if (ImGui::Button("Refresh"))
+			refresh = true;
 	}
 	ImGui::End();
+	return refresh;
 }
 
 

--- a/src/ui/ImGuiPanels.cpp
+++ b/src/ui/ImGuiPanels.cpp
@@ -55,7 +55,7 @@ bool drawFormulaPanel(FractalParams & fp)
 
 	// Formula selector
 	const char * formulas[] = {
-		"mandalay", "amazingbox", "amazingbox_mandalay", "mandelbulb", "hopfbrot",
+		"amosersine", "mandalay", "amazingbox", "amazingbox_mandalay", "mandelbulb", "hopfbrot",
 		"burningship4d", "lambdabulb", "octopus", "mengersponge", "cubicbulb",
 		"pseudokleinian", "riemannsphere", "spheretree", "benesipine2", "sphere"
 	};
@@ -80,7 +80,15 @@ bool drawFormulaPanel(FractalParams & fp)
 	// Formula-specific parameters
 	const std::string & name = fp.formula_name;
 
-	if (name == "mandalay")
+	if (name == "amosersine")
+	{
+		ImGui::Separator();
+		ImGui::Text("AmoserSine Parameters");
+		changed |= SliderReal("Scale##amosersine", &fp.amosersine_scale, 0.5f, 5.0f);
+		changed |= DragVec3r("Julia C##amosersine", fp.amosersine_julia_c, 0.01f);
+		changed |= ImGui::Checkbox("Julia Mode##amosersine", &fp.amosersine_julia_mode);
+	}
+	else if (name == "mandalay")
 	{
 		ImGui::Separator();
 		ImGui::Text("MandalayKIFS Parameters");
@@ -250,6 +258,7 @@ bool drawRenderSettingsPanel(RenderSettings & settings)
 
 	changed |= ImGui::SliderInt("Max Bounces", &settings.max_bounces, 1, 32);
 	changed |= ImGui::SliderInt("Target Passes", &settings.target_passes, 1, 10000);
+	changed |= ImGui::SliderInt("Preview Divisor", &settings.preview_divisor, 1, 64);
 
 	return changed;
 }

--- a/src/ui/ImGuiPanels.cpp
+++ b/src/ui/ImGuiPanels.cpp
@@ -1,0 +1,372 @@
+#include "ImGuiPanels.h"
+#include "SceneSerializer.h"
+#include "imgui.h"
+
+#include <cstring>
+#include <cmath>
+
+
+static bool SliderReal(const char * label, real * v, real v_min, real v_max, const char * format = "%.4f")
+{
+#if USE_DOUBLE
+	double dv = *v;
+	bool changed = ImGui::SliderScalar(label, ImGuiDataType_Double, &dv, &v_min, &v_max, format);
+	if (changed) *v = dv;
+	return changed;
+#else
+	return ImGui::SliderFloat(label, v, v_min, v_max, format);
+#endif
+}
+
+static bool DragReal(const char * label, real * v, real speed = 0.01f, real v_min = 0, real v_max = 0, const char * format = "%.4f")
+{
+#if USE_DOUBLE
+	double dv = *v;
+	bool changed = ImGui::DragScalar(label, ImGuiDataType_Double, &dv, (float)speed, &v_min, &v_max, format);
+	if (changed) *v = dv;
+	return changed;
+#else
+	return ImGui::DragFloat(label, v, speed, v_min, v_max, format);
+#endif
+}
+
+static bool DragVec3r(const char * label, vec3r & v, real speed = 0.01f)
+{
+#if USE_DOUBLE
+	double dv[3] = { v.x(), v.y(), v.z() };
+	bool changed = ImGui::DragScalarN(label, ImGuiDataType_Double, dv, 3, (float)speed);
+	if (changed) { v.x() = dv[0]; v.y() = dv[1]; v.z() = dv[2]; }
+	return changed;
+#else
+	float fv[3] = { v.x(), v.y(), v.z() };
+	bool changed = ImGui::DragFloat3(label, fv, speed);
+	if (changed) { v.x() = fv[0]; v.y() = fv[1]; v.z() = fv[2]; }
+	return changed;
+#endif
+}
+
+
+bool drawFormulaPanel(FractalParams & fp)
+{
+	bool changed = false;
+
+	if (!ImGui::CollapsingHeader("Fractal Formula", ImGuiTreeNodeFlags_DefaultOpen))
+		return false;
+
+	// Formula selector
+	const char * formulas[] = {
+		"mandalay", "amazingbox", "amazingbox_mandalay", "mandelbulb", "hopfbrot",
+		"burningship4d", "lambdabulb", "octopus", "mengersponge", "cubicbulb",
+		"pseudokleinian", "riemannsphere", "spheretree", "benesipine2", "sphere"
+	};
+	const int num_formulas = sizeof(formulas) / sizeof(formulas[0]);
+
+	int current = 0;
+	for (int i = 0; i < num_formulas; i++)
+		if (fp.formula_name == formulas[i]) { current = i; break; }
+
+	if (ImGui::Combo("Formula", &current, formulas, num_formulas))
+	{
+		fp.formula_name = formulas[current];
+		changed = true;
+	}
+
+	// Common DE parameters
+	changed |= ImGui::SliderInt("Max Iterations", &fp.max_iters, 1, 200);
+	changed |= SliderReal("Radius", &fp.radius, 0.1f, 10.0f);
+	changed |= SliderReal("Step Scale", &fp.step_scale, 0.01f, 2.0f);
+	changed |= SliderReal("Bailout Radius^2", &fp.bailout_radius2, 1.0f, 10000.0f, "%.1f");
+
+	// Formula-specific parameters
+	const std::string & name = fp.formula_name;
+
+	if (name == "mandalay")
+	{
+		ImGui::Separator();
+		ImGui::Text("MandalayKIFS Parameters");
+		changed |= SliderReal("Scale##mandalay", &fp.mandalay_scale, -5.0f, 5.0f);
+		changed |= SliderReal("Min R2##mandalay", &fp.mandalay_min_r2, 0.0f, 2.0f);
+		changed |= SliderReal("Folding Offset##mandalay", &fp.mandalay_folding_offset, 0.0f, 3.0f);
+		changed |= SliderReal("Z Tower##mandalay", &fp.mandalay_z_tower, -2.0f, 2.0f);
+		changed |= SliderReal("XY Tower##mandalay", &fp.mandalay_xy_tower, -2.0f, 2.0f);
+		changed |= DragVec3r("Rotate##mandalay", fp.mandalay_rotate, 0.005f);
+		changed |= DragVec3r("Julia C##mandalay", fp.mandalay_julia_c, 0.01f);
+		changed |= ImGui::Checkbox("Julia Mode##mandalay", &fp.mandalay_julia_mode);
+	}
+	else if (name == "amazingbox")
+	{
+		ImGui::Separator();
+		ImGui::Text("Amazingbox Parameters");
+		changed |= SliderReal("Scale##amazingbox", &fp.amazingbox_scale, -5.0f, 5.0f);
+		changed |= SliderReal("Min R2##amazingbox", &fp.amazingbox_min_r2, 0.0f, 2.0f);
+		changed |= SliderReal("Fix R2##amazingbox", &fp.amazingbox_fix_r2, 0.0f, 2.0f);
+		changed |= SliderReal("Fold Limit##amazingbox", &fp.amazingbox_fold_limit, 0.0f, 3.0f);
+		changed |= ImGui::Checkbox("Julia Mode##amazingbox", &fp.amazingbox_julia_mode);
+	}
+	else if (name == "amazingbox_mandalay")
+	{
+		ImGui::Separator();
+		ImGui::Text("Hybrid Amazingbox Parameters");
+		changed |= SliderReal("AB Scale", &fp.hybrid_amazingbox_scale, -5.0f, 5.0f);
+		changed |= SliderReal("AB Fold Limit", &fp.hybrid_amazingbox_fold_limit, 0.0f, 3.0f);
+		changed |= SliderReal("AB Min R2", &fp.hybrid_amazingbox_min_r2, 0.0f, 2.0f);
+
+		ImGui::Separator();
+		ImGui::Text("Hybrid Mandalay Parameters");
+		changed |= SliderReal("MK Scale", &fp.hybrid_mandalay_scale, -5.0f, 5.0f);
+		changed |= SliderReal("MK Folding Offset", &fp.hybrid_mandalay_folding_offset, 0.0f, 3.0f);
+		changed |= SliderReal("MK Z Tower", &fp.hybrid_mandalay_z_tower, -2.0f, 2.0f);
+		changed |= SliderReal("MK XY Tower", &fp.hybrid_mandalay_xy_tower, -2.0f, 2.0f);
+		changed |= DragVec3r("MK Rotate", fp.hybrid_mandalay_rotate, 0.005f);
+		changed |= ImGui::Checkbox("MK Julia Mode", &fp.hybrid_mandalay_julia_mode);
+	}
+	else if (name == "lambdabulb")
+	{
+		ImGui::Separator();
+		ImGui::Text("Lambdabulb Parameters");
+		changed |= SliderReal("Power##lambdabulb", &fp.lambdabulb_power, 2.0f, 8.0f);
+		changed |= DragVec3r("C##lambdabulb", fp.lambdabulb_c, 0.005f);
+	}
+	else if (name == "octopus")
+	{
+		ImGui::Separator();
+		ImGui::Text("Octopus Parameters");
+		changed |= SliderReal("XZ Mul##octopus", &fp.octopus_xz_mul, 0.0f, 3.0f);
+		changed |= SliderReal("Sq Mul##octopus", &fp.octopus_sq_mul, 0.0f, 3.0f);
+		changed |= ImGui::Checkbox("Julia Mode##octopus", &fp.octopus_julia_mode);
+	}
+	else if (name == "cubicbulb")
+	{
+		ImGui::Separator();
+		ImGui::Text("Cubicbulb Parameters");
+		changed |= SliderReal("Y Mul##cubicbulb", &fp.cubicbulb_y_mul, 0.0f, 6.0f);
+		changed |= SliderReal("Z Mul##cubicbulb", &fp.cubicbulb_z_mul, 0.0f, 6.0f);
+		changed |= SliderReal("Aux Mul##cubicbulb", &fp.cubicbulb_aux_mul, 0.0f, 3.0f);
+		changed |= DragVec3r("C##cubicbulb", fp.cubicbulb_c, 0.005f);
+		changed |= ImGui::Checkbox("Julia Mode##cubicbulb", &fp.cubicbulb_julia_mode);
+	}
+	else if (name == "mengersponge")
+	{
+		ImGui::Separator();
+		ImGui::Text("Menger Sponge Parameters");
+		changed |= SliderReal("Scale##menger", &fp.mengersponge_scale, 1.0f, 6.0f);
+		changed |= DragVec3r("Scale Centre##menger", fp.mengersponge_scale_centre, 0.01f);
+	}
+	else if (name == "benesipine2")
+	{
+		ImGui::Separator();
+		ImGui::Text("BenesiPine2 Parameters");
+		changed |= SliderReal("Scale##benesi", &fp.benesipine2_scale, 0.5f, 5.0f);
+		changed |= SliderReal("Offset##benesi", &fp.benesipine2_offset, 0.0f, 2.0f);
+		changed |= ImGui::Checkbox("Julia Mode##benesi", &fp.benesipine2_julia_mode);
+	}
+	else if (name == "riemannsphere")
+	{
+		ImGui::Separator();
+		ImGui::Text("Riemann Sphere Parameters");
+		changed |= SliderReal("Scale##riemann", &fp.riemannsphere_scale, -3.0f, 3.0f);
+		changed |= SliderReal("S Shift##riemann", &fp.riemannsphere_s_shift, -2.0f, 2.0f);
+		changed |= SliderReal("T Shift##riemann", &fp.riemannsphere_t_shift, -2.0f, 2.0f);
+		changed |= SliderReal("X Shift##riemann", &fp.riemannsphere_x_shift, -2.0f, 2.0f);
+		changed |= SliderReal("R Shift##riemann", &fp.riemannsphere_r_shift, -2.0f, 2.0f);
+		changed |= SliderReal("R Power##riemann", &fp.riemannsphere_r_pow, 1.0f, 8.0f);
+	}
+	else if (name == "pseudokleinian")
+	{
+		ImGui::Separator();
+		ImGui::Text("PseudoKleinian Parameters");
+		changed |= ImGui::SliderFloat4("Mins##pk", fp.pseudokleinian_mins, -2.0f, 2.0f);
+		changed |= ImGui::SliderFloat4("Maxs##pk", fp.pseudokleinian_maxs, -2.0f, 2.0f);
+	}
+	else if (name == "hopfbrot")
+	{
+		ImGui::Separator();
+		ImGui::Text("Hopfbrot Parameters");
+		changed |= SliderReal("Scene Scale##hopf", &fp.hopfbrot_scene_scale, 0.5f, 5.0f);
+	}
+
+	return changed;
+}
+
+
+bool drawCameraPanel(CameraParams & camera)
+{
+	bool changed = false;
+
+	if (!ImGui::CollapsingHeader("Camera", ImGuiTreeNodeFlags_DefaultOpen))
+		return false;
+
+	changed |= DragVec3r("Position", camera.position, 0.02f);
+	changed |= DragVec3r("Look At", camera.look_at, 0.02f);
+	changed |= SliderReal("FOV (deg)", &camera.fov_deg, 10.0f, 170.0f, "%.1f");
+	changed |= SliderReal("DOF Amount", &camera.dof_amount, 0.0f, 2.0f);
+	changed |= SliderReal("Lens Radius", &camera.lens_radius, 0.0f, 0.1f, "%.5f");
+	changed |= SliderReal("Focal Dist Scale", &camera.focal_dist_scale, 0.01f, 2.0f);
+
+	return changed;
+}
+
+
+bool drawMaterialPanel(FractalParams & fp)
+{
+	bool changed = false;
+
+	if (!ImGui::CollapsingHeader("Material"))
+		return false;
+
+	changed |= ImGui::ColorEdit3("Albedo", &fp.albedo.x());
+	changed |= ImGui::ColorEdit3("Emission", &fp.emission.x());
+	changed |= ImGui::Checkbox("Use Fresnel", &fp.use_fresnel);
+	if (fp.use_fresnel)
+		changed |= ImGui::SliderFloat("R0 (Fresnel)", &fp.r0, 0.0f, 1.0f);
+	changed |= ImGui::Checkbox("Orbit Trap Colouring", &fp.use_orbit_trap_colouring);
+
+	return changed;
+}
+
+
+bool drawLightPanel(LightParams & light)
+{
+	bool changed = false;
+
+	if (!ImGui::CollapsingHeader("Lighting"))
+		return false;
+
+	changed |= DragVec3r("Light Position", light.light_pos, 0.1f);
+	changed |= DragReal("Intensity", &light.light_intensity, 5.0f, 0.0f, 10000.0f, "%.0f");
+	changed |= ImGui::ColorEdit3("Sky Up Colour", &light.sky_up_colour.x());
+	changed |= ImGui::ColorEdit3("Sky Horizon Colour", &light.sky_hz_colour.x());
+
+	return changed;
+}
+
+
+bool drawRenderSettingsPanel(RenderSettings & settings)
+{
+	bool changed = false;
+
+	if (!ImGui::CollapsingHeader("Render Settings"))
+		return false;
+
+	changed |= ImGui::SliderInt("Max Bounces", &settings.max_bounces, 1, 32);
+	changed |= ImGui::SliderInt("Target Passes", &settings.target_passes, 1, 10000);
+
+	return changed;
+}
+
+
+void drawStatsOverlay(int passes, int xres, int yres, float fps)
+{
+	ImGui::SetNextWindowPos(ImVec2(10, 10), ImGuiCond_Always);
+	ImGui::SetNextWindowBgAlpha(0.5f);
+	if (ImGui::Begin("Stats", nullptr,
+		ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize |
+		ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav |
+		ImGuiWindowFlags_NoMove))
+	{
+		ImGui::Text("Resolution: %d x %d", xres, yres);
+		ImGui::Text("Passes: %d", passes);
+		ImGui::Text("FPS: %.1f", fps);
+	}
+	ImGui::End();
+}
+
+
+bool drawFileMenu(SceneParams & params)
+{
+	static char save_path[256] = "scene.json";
+	static char status_msg[256] = "";
+	bool loaded = false;
+
+	if (ImGui::CollapsingHeader("File"))
+	{
+		ImGui::InputText("Path##file", save_path, sizeof(save_path));
+
+		if (ImGui::Button("Save Scene"))
+		{
+			if (saveScene(save_path, params))
+				snprintf(status_msg, sizeof(status_msg), "Saved: %s", save_path);
+			else
+				snprintf(status_msg, sizeof(status_msg), "Save failed: %s", save_path);
+		}
+
+		ImGui::SameLine();
+		if (ImGui::Button("Load Scene"))
+		{
+			if (loadScene(save_path, params))
+			{
+				snprintf(status_msg, sizeof(status_msg), "Loaded: %s", save_path);
+				loaded = true;
+			}
+			else
+				snprintf(status_msg, sizeof(status_msg), "Load failed: %s", save_path);
+		}
+
+		if (status_msg[0])
+			ImGui::TextWrapped("%s", status_msg);
+	}
+
+	return loaded;
+}
+
+
+void drawAnimationPanel(AnimationRenderer & anim_renderer, AnimationSettings & anim_settings,
+	const Timeline & timeline, const SceneParams & params, int num_threads)
+{
+	if (!ImGui::CollapsingHeader("Render Animation"))
+		return;
+
+	if (anim_renderer.isRendering())
+	{
+		// Progress display
+		const int cur_frame = anim_renderer.getCurrentFrame();
+		const int tot_frames = anim_renderer.getTotalFrames();
+		const int cur_pass = anim_renderer.getCurrentPass();
+		const int tot_passes = anim_renderer.getTotalPasses();
+
+		const float frame_progress = (tot_frames > 0) ? (float)cur_frame / tot_frames : 0;
+		const float pass_progress = (tot_passes > 0) ? (float)cur_pass / tot_passes : 0;
+
+		ImGui::Text("Frame %d / %d", cur_frame + 1, tot_frames);
+		ImGui::ProgressBar(frame_progress, ImVec2(-1, 0), "Frames");
+
+		ImGui::Text("Pass %d / %d", cur_pass + 1, tot_passes);
+		ImGui::ProgressBar(pass_progress, ImVec2(-1, 0), "Passes");
+
+		ImGui::TextWrapped("%s", anim_renderer.getStatusMessage().c_str());
+
+		if (ImGui::Button("Cancel Render"))
+			anim_renderer.cancel();
+	}
+	else
+	{
+		// Settings
+		ImGui::SliderInt("SPP##anim", &anim_settings.target_spp, 1, 2048);
+		ImGui::SliderInt("Width##anim", &anim_settings.output_xres, 320, 3840);
+		ImGui::SliderInt("Height##anim", &anim_settings.output_yres, 180, 2160);
+
+		static char output_dir[256] = "anim_output";
+		ImGui::InputText("Output Dir##anim", output_dir, sizeof(output_dir));
+		anim_settings.output_dir = output_dir;
+
+		ImGui::Checkbox("Encode MP4##anim", &anim_settings.encode_mp4);
+
+		const int total_frames = timeline.getTotalFrames();
+		ImGui::Text("Timeline: %.1f s @ %d fps = %d frames", timeline.duration_seconds, timeline.fps, total_frames);
+		ImGui::Text("Keyframes: %d", (int)timeline.keyframes.size());
+
+		const bool can_render = !timeline.keyframes.empty() && total_frames > 0;
+
+		if (!can_render)
+			ImGui::TextColored(ImVec4(1, 0.5f, 0, 1), "Add at least one keyframe to render animation.");
+
+		ImGui::BeginDisabled(!can_render);
+		if (ImGui::Button("Render Animation"))
+			anim_renderer.start(timeline, params, anim_settings, num_threads);
+		ImGui::EndDisabled();
+
+		// Show status from last render
+		if (anim_renderer.isFinished())
+			ImGui::TextWrapped("%s", anim_renderer.getStatusMessage().c_str());
+	}
+}

--- a/src/ui/ImGuiPanels.cpp
+++ b/src/ui/ImGuiPanels.cpp
@@ -255,7 +255,7 @@ bool drawRenderSettingsPanel(RenderSettings & settings)
 }
 
 
-bool drawStatsOverlay(int passes, int xres, int yres, float fps)
+bool drawStatsOverlay(int passes, int target_passes, int xres, int yres, float fps)
 {
 	bool refresh = false;
 	ImGui::SetNextWindowPos(ImVec2(10, 10), ImGuiCond_Always);
@@ -266,8 +266,18 @@ bool drawStatsOverlay(int passes, int xres, int yres, float fps)
 		ImGuiWindowFlags_NoMove))
 	{
 		ImGui::Text("Resolution: %d x %d", xres, yres);
-		ImGui::Text("Passes: %d", passes);
+		ImGui::Text("Passes: %d / %d", passes, target_passes);
 		ImGui::Text("FPS: %.1f", fps);
+
+		// Log2 sampling progress slider
+		const int full_res_passes = std::max(0, passes - 2);
+		const float log2_current = (full_res_passes > 0) ? std::log2((float)full_res_passes) : 0;
+		const float log2_target  = (target_passes > 0)   ? std::log2((float)target_passes)   : 1;
+		float progress = log2_current; // non-editable, just for display
+		char label[64];
+		snprintf(label, sizeof(label), "%.1f / %.1f", log2_current, log2_target);
+		ImGui::SliderFloat("log2(spp)", &progress, 0, log2_target, label, ImGuiSliderFlags_NoInput);
+
 		if (ImGui::Button("Refresh"))
 			refresh = true;
 	}

--- a/src/ui/ImGuiPanels.cpp
+++ b/src/ui/ImGuiPanels.cpp
@@ -270,7 +270,7 @@ bool drawStatsOverlay(int passes, int target_passes, int xres, int yres, float f
 		ImGui::Text("FPS: %.1f", fps);
 
 		// Log2 sampling progress slider
-		const int full_res_passes = std::max(0, passes - 2);
+		const int full_res_passes = std::max(0, passes - 4);
 		const float log2_current = (full_res_passes > 0) ? std::log2((float)full_res_passes) : 0;
 		const float log2_target  = (target_passes > 0)   ? std::log2((float)target_passes)   : 1;
 		float progress = log2_current; // non-editable, just for display

--- a/src/ui/ImGuiPanels.h
+++ b/src/ui/ImGuiPanels.h
@@ -11,7 +11,7 @@ bool drawMaterialPanel(FractalParams & fp);
 bool drawLightPanel(LightParams & light);
 bool drawRenderSettingsPanel(RenderSettings & settings);
 // Returns true if the Refresh button was pressed
-bool drawStatsOverlay(int passes, int xres, int yres, float fps);
+bool drawStatsOverlay(int passes, int target_passes, int xres, int yres, float fps);
 
 // File menu: returns true if params were loaded (caller should updateParams)
 bool drawFileMenu(SceneParams & params);

--- a/src/ui/ImGuiPanels.h
+++ b/src/ui/ImGuiPanels.h
@@ -10,7 +10,8 @@ bool drawCameraPanel(CameraParams & camera);
 bool drawMaterialPanel(FractalParams & fp);
 bool drawLightPanel(LightParams & light);
 bool drawRenderSettingsPanel(RenderSettings & settings);
-void drawStatsOverlay(int passes, int xres, int yres, float fps);
+// Returns true if the Refresh button was pressed
+bool drawStatsOverlay(int passes, int xres, int yres, float fps);
 
 // File menu: returns true if params were loaded (caller should updateParams)
 bool drawFileMenu(SceneParams & params);

--- a/src/ui/ImGuiPanels.h
+++ b/src/ui/ImGuiPanels.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "renderer/SceneParams.h"
+#include "AnimationRenderer.h"
+#include "Timeline.h"
+
+// Returns true if any parameter was changed
+bool drawFormulaPanel(FractalParams & fp);
+bool drawCameraPanel(CameraParams & camera);
+bool drawMaterialPanel(FractalParams & fp);
+bool drawLightPanel(LightParams & light);
+bool drawRenderSettingsPanel(RenderSettings & settings);
+void drawStatsOverlay(int passes, int xres, int yres, float fps);
+
+// File menu: returns true if params were loaded (caller should updateParams)
+bool drawFileMenu(SceneParams & params);
+
+// Animation rendering panel
+void drawAnimationPanel(AnimationRenderer & anim_renderer, AnimationSettings & anim_settings,
+	const Timeline & timeline, const SceneParams & params, int num_threads);

--- a/src/ui/InteractiveCamera.cpp
+++ b/src/ui/InteractiveCamera.cpp
@@ -75,14 +75,14 @@ bool InteractiveCamera::processEvent(const SDL_Event & event, CameraParams & cam
 
 	bool changed = false;
 
-	if (event.type == SDL_MOUSEBUTTONDOWN && event.button.button == SDL_BUTTON_RIGHT)
+	if (event.type == SDL_MOUSEBUTTONDOWN && (event.button.button == SDL_BUTTON_LEFT || event.button.button == SDL_BUTTON_RIGHT))
 	{
 		mouse_captured = true;
 		last_mouse_x = event.button.x;
 		last_mouse_y = event.button.y;
 		SDL_SetRelativeMouseMode(SDL_TRUE);
 	}
-	else if (event.type == SDL_MOUSEBUTTONUP && event.button.button == SDL_BUTTON_RIGHT)
+	else if (event.type == SDL_MOUSEBUTTONUP && (event.button.button == SDL_BUTTON_LEFT || event.button.button == SDL_BUTTON_RIGHT))
 	{
 		mouse_captured = false;
 		SDL_SetRelativeMouseMode(SDL_FALSE);

--- a/src/ui/InteractiveCamera.cpp
+++ b/src/ui/InteractiveCamera.cpp
@@ -1,0 +1,142 @@
+#include "InteractiveCamera.h"
+
+#include <cmath>
+#include "imgui.h"
+
+
+void InteractiveCamera::initFromCamera(const CameraParams & camera)
+{
+	const vec3r dir = normalise(camera.look_at - camera.position);
+	yaw   = (float)std::atan2(dir.x(), dir.z());
+	pitch = (float)std::asin(std::max(-1.0, std::min(1.0, (double)dir.y())));
+}
+
+
+bool InteractiveCamera::update(float dt, const Uint8 * keyboard, CameraParams & camera)
+{
+	// Don't process keyboard input if ImGui wants it
+	if (ImGui::GetIO().WantCaptureKeyboard)
+		return false;
+
+	bool changed = false;
+	const float speed = move_speed * dt * (keyboard[SDL_SCANCODE_LSHIFT] ? fast_multiplier : 1.0f);
+
+	camera.recompute();
+
+	if (orbit_mode)
+	{
+		// WASD orbits around look_at
+		const real dist = length(camera.position - camera.look_at);
+		if (keyboard[SDL_SCANCODE_W]) { pitch += speed; changed = true; }
+		if (keyboard[SDL_SCANCODE_S]) { pitch -= speed; changed = true; }
+		if (keyboard[SDL_SCANCODE_A]) { yaw -= speed; changed = true; }
+		if (keyboard[SDL_SCANCODE_D]) { yaw += speed; changed = true; }
+
+		// Clamp pitch
+		pitch = std::max(-1.5f, std::min(1.5f, pitch));
+
+		if (changed)
+		{
+			camera.position = camera.look_at + vec3r{
+				std::sin(yaw) * std::cos(pitch),
+				std::sin(pitch),
+				std::cos(yaw) * std::cos(pitch)
+			} * dist;
+		}
+	}
+	else
+	{
+		// Free-fly mode: WASD + Q/E
+		vec3r move = { 0, 0, 0 };
+		if (keyboard[SDL_SCANCODE_W]) move = move + camera.forward * speed;
+		if (keyboard[SDL_SCANCODE_S]) move = move - camera.forward * speed;
+		if (keyboard[SDL_SCANCODE_A]) move = move - camera.right * speed;
+		if (keyboard[SDL_SCANCODE_D]) move = move + camera.right * speed;
+		if (keyboard[SDL_SCANCODE_Q]) move = move - camera.up * speed;
+		if (keyboard[SDL_SCANCODE_E]) move = move + camera.up * speed;
+
+		if (length(move) > 1e-8f)
+		{
+			camera.position = camera.position + move;
+			camera.look_at  = camera.look_at + move;
+			changed = true;
+		}
+	}
+
+	return changed;
+}
+
+
+bool InteractiveCamera::processEvent(const SDL_Event & event, CameraParams & camera)
+{
+	// Don't process mouse input if ImGui wants it
+	if (ImGui::GetIO().WantCaptureMouse)
+		return false;
+
+	bool changed = false;
+
+	if (event.type == SDL_MOUSEBUTTONDOWN && event.button.button == SDL_BUTTON_RIGHT)
+	{
+		mouse_captured = true;
+		last_mouse_x = event.button.x;
+		last_mouse_y = event.button.y;
+		SDL_SetRelativeMouseMode(SDL_TRUE);
+	}
+	else if (event.type == SDL_MOUSEBUTTONUP && event.button.button == SDL_BUTTON_RIGHT)
+	{
+		mouse_captured = false;
+		SDL_SetRelativeMouseMode(SDL_FALSE);
+	}
+	else if (event.type == SDL_MOUSEMOTION && mouse_captured)
+	{
+		const float dx = (float)event.motion.xrel * mouse_sensitivity;
+		const float dy = (float)event.motion.yrel * mouse_sensitivity;
+
+		yaw   += dx;
+		pitch -= dy;
+		pitch = std::max(-1.5f, std::min(1.5f, pitch));
+
+		if (orbit_mode)
+		{
+			const real dist = length(camera.position - camera.look_at);
+			camera.position = camera.look_at + vec3r{
+				std::sin(yaw) * std::cos(pitch),
+				std::sin(pitch),
+				std::cos(yaw) * std::cos(pitch)
+			} * dist;
+		}
+		else
+		{
+			// Update look_at from yaw/pitch relative to position
+			const vec3r dir = {
+				std::sin(yaw) * std::cos(pitch),
+				std::sin(pitch),
+				std::cos(yaw) * std::cos(pitch)
+			};
+			camera.look_at = camera.position + dir;
+		}
+
+		changed = true;
+	}
+	else if (event.type == SDL_MOUSEWHEEL)
+	{
+		if (orbit_mode)
+		{
+			// Zoom in/out by changing distance to look_at
+			camera.recompute();
+			const real dist = length(camera.position - camera.look_at);
+			const real new_dist = dist * (1.0f - event.wheel.y * scroll_speed);
+			camera.position = camera.look_at - camera.forward * new_dist;
+			changed = true;
+		}
+	}
+	else if (event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_TAB)
+	{
+		if (!ImGui::GetIO().WantCaptureKeyboard)
+		{
+			orbit_mode = !orbit_mode;
+		}
+	}
+
+	return changed;
+}

--- a/src/ui/InteractiveCamera.h
+++ b/src/ui/InteractiveCamera.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "renderer/CameraParams.h"
+#include <SDL2/SDL.h>
+
+
+struct InteractiveCamera
+{
+	// Movement speed
+	float move_speed      = 1.0f;
+	float fast_multiplier = 3.0f;
+	float mouse_sensitivity = 0.003f;
+	float scroll_speed    = 0.1f;
+
+	// Orbit mode
+	bool orbit_mode = false;
+
+	// Internal state
+	float yaw   = 0;
+	float pitch = 0;
+	bool  mouse_captured = false;
+	int   last_mouse_x = 0, last_mouse_y = 0;
+
+	// Initialize yaw/pitch from current camera state
+	void initFromCamera(const CameraParams & camera);
+
+	// Process input and update camera. Returns true if camera changed.
+	bool update(float dt, const Uint8 * keyboard, CameraParams & camera);
+
+	// Process SDL events for mouse input. Returns true if camera changed.
+	bool processEvent(const SDL_Event & event, CameraParams & camera);
+};

--- a/src/ui/RenderController.cpp
+++ b/src/ui/RenderController.cpp
@@ -82,6 +82,9 @@ void RenderController::managerFunc()
 		current_xres = render_xres;
 		current_yres = render_yres;
 
+		// Mark output as not safe to read while we modify and render
+		display_ready = false;
+
 		// Resize/clear output if resolution changed
 		{
 			std::lock_guard<std::mutex> lock(output_mutex);
@@ -162,5 +165,6 @@ void RenderController::managerFunc()
 			output.passes = render_pass + 1;
 		}
 		completed_passes.fetch_add(1);
+		display_ready = true;
 	}
 }

--- a/src/ui/RenderController.cpp
+++ b/src/ui/RenderController.cpp
@@ -120,7 +120,7 @@ void RenderController::managerFunc()
 
 				Scene local_scene(render_scene);
 
-				constexpr int bucket_size = 64;
+				constexpr int bucket_size = 16;
 				const int x_buckets = (xres + bucket_size - 1) / bucket_size;
 				const int y_buckets = (yres + bucket_size - 1) / bucket_size;
 				const int num_buckets = x_buckets * y_buckets;

--- a/src/ui/RenderController.cpp
+++ b/src/ui/RenderController.cpp
@@ -155,7 +155,12 @@ void RenderController::managerFunc()
 		// If generation changed during render, restart
 		if (generation.load() != gen) continue;
 
-		// Pass completed
+		// Pass completed - update the pass count used for normalisation
+		{
+			std::lock_guard<std::mutex> lock(output_mutex);
+			const int render_pass = (pass < 2) ? 0 : pass - 2;
+			output.passes = render_pass + 1;
+		}
 		completed_passes.fetch_add(1);
 	}
 }

--- a/src/ui/RenderController.cpp
+++ b/src/ui/RenderController.cpp
@@ -1,0 +1,161 @@
+#include "RenderController.h"
+
+#include <algorithm>
+#include <chrono>
+
+
+RenderController::RenderController(int num_threads_, int xres, int yres)
+	: output(xres, yres), full_xres(xres), full_yres(yres), num_threads(num_threads_)
+{
+	current_xres = xres;
+	current_yres = yres;
+}
+
+RenderController::~RenderController()
+{
+	stop();
+}
+
+void RenderController::updateParams(const SceneParams & new_params)
+{
+	{
+		std::lock_guard<std::mutex> lock(params_mutex);
+		params = new_params;
+	}
+
+	// Rebuild scene
+	{
+		std::lock_guard<std::mutex> lock(scene_mutex);
+		buildScene(scene, params.fractal);
+	}
+
+	// Signal restart
+	completed_passes = 0;
+	generation.fetch_add(1);
+}
+
+void RenderController::reloadHDREnv()
+{
+	// Placeholder - HDR loading requires stb_image which is only available
+	// in translation units that define STB_IMAGE_IMPLEMENTATION
+}
+
+void RenderController::start()
+{
+	if (running) return;
+	running = true;
+
+	// Initial scene build
+	{
+		std::lock_guard<std::mutex> lock(scene_mutex);
+		buildScene(scene, params.fractal);
+	}
+
+	manager_thread = std::thread(&RenderController::managerFunc, this);
+}
+
+void RenderController::stop()
+{
+	running = false;
+	if (manager_thread.joinable())
+		manager_thread.join();
+}
+
+void RenderController::managerFunc()
+{
+	std::vector<std::thread> workers(num_threads);
+
+	while (running)
+	{
+		const uint64_t gen = generation.load();
+		const int pass = completed_passes.load();
+
+		// Determine sub-resolution level
+		// pass 0: 1/4 res, pass 1: 1/2 res, pass 2+: full res
+		int render_xres = full_xres;
+		int render_yres = full_yres;
+		if (pass == 0)      { render_xres /= 4; render_yres /= 4; }
+		else if (pass == 1) { render_xres /= 2; render_yres /= 2; }
+		render_xres = std::max(render_xres, 32);
+		render_yres = std::max(render_yres, 18);
+
+		current_xres = render_xres;
+		current_yres = render_yres;
+
+		// Resize/clear output if resolution changed
+		{
+			std::lock_guard<std::mutex> lock(output_mutex);
+			if (output.xres != render_xres || output.yres != render_yres)
+				output.resize(render_xres, render_yres);
+			else if (pass <= 2)
+				output.clear();
+		}
+
+		// Snapshot params
+		CameraParams camera;
+		LightParams light;
+		RenderSettings settings;
+		{
+			std::lock_guard<std::mutex> lock(params_mutex);
+			camera = params.camera;
+			light = params.light;
+			settings = params.render;
+		}
+		camera.recompute();
+
+		// Get a scene snapshot
+		Scene * scene_ptr;
+		{
+			std::lock_guard<std::mutex> lock(scene_mutex);
+			scene_ptr = &scene;
+		}
+
+		// Use the pass index, but for sub-resolution levels always use pass 0
+		const int render_pass = (pass < 2) ? 0 : pass - 2;
+
+		// Render one pass using bucket-based multi-threading
+		ThreadControl thread_control = { 1 }; // 1 pass at a time
+
+		for (std::thread & t : workers)
+		{
+			t = std::thread([&]()
+			{
+				const int xres = render_xres;
+				const int yres = render_yres;
+
+				Scene local_scene(*scene_ptr);
+
+				constexpr int bucket_size = 32;
+				const int x_buckets = (xres + bucket_size - 1) / bucket_size;
+				const int y_buckets = (yres + bucket_size - 1) / bucket_size;
+				const int num_buckets = x_buckets * y_buckets;
+
+				while (true)
+				{
+					if (generation.load() != gen) break; // Cancelled
+
+					const int bucket = thread_control.next_bucket.fetch_add(1);
+					if (bucket >= num_buckets) break;
+
+					const int bucket_y = bucket / x_buckets;
+					const int bucket_x = bucket - x_buckets * bucket_y;
+					const int x0 = bucket_x * bucket_size, x1 = std::min(x0 + bucket_size, xres);
+					const int y0 = bucket_y * bucket_size, y1 = std::min(y0 + bucket_size, yres);
+
+					for (int y = y0; y < y1; ++y)
+					for (int x = x0; x < x1; ++x)
+						render(x, y, 0, render_pass, 0, camera, light, settings, local_scene, output, &hdr_env);
+				}
+			});
+		}
+
+		for (std::thread & t : workers)
+			t.join();
+
+		// If generation changed during render, restart
+		if (generation.load() != gen) continue;
+
+		// Pass completed
+		completed_passes.fetch_add(1);
+	}
+}

--- a/src/ui/RenderController.h
+++ b/src/ui/RenderController.h
@@ -48,8 +48,10 @@ struct RenderController
 	// HDR environment map
 	HDREnvironment hdr_env;
 
-	// True when a pass is complete and output is safe to read (no workers writing)
-	std::atomic<bool> display_ready{false};
+	// Set to completed_passes value after each pass finishes (output is valid).
+	// Reset to 0 when output is resized/cleared (output is invalid).
+	// The UI updates the display when this advances past its last-seen value.
+	std::atomic<int> safe_display_passes{0};
 
 private:
 	void managerFunc();

--- a/src/ui/RenderController.h
+++ b/src/ui/RenderController.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "renderer/Renderer.h"
+#include "renderer/SceneParams.h"
+#include "renderer/SceneBuilder.h"
+
+
+struct RenderController
+{
+	RenderController(int num_threads, int xres, int yres);
+	~RenderController();
+
+	// Update scene parameters; triggers a render restart
+	void updateParams(const SceneParams & new_params);
+
+	// Reload HDR environment from current params.light.hdr_env_path
+	void reloadHDREnv();
+
+	// Start / stop the render loop
+	void start();
+	void stop();
+
+	// Get current completed passes (for display)
+	int getCompletedPasses() const { return completed_passes.load(); }
+
+	// Get current generation (incremented on each param change)
+	uint64_t getGeneration() const { return generation.load(); }
+
+	// Current render output - lock output_mutex before accessing
+	RenderOutput output;
+	std::mutex output_mutex;
+
+	// Current resolution being rendered (may differ from output due to sub-resolution)
+	int getCurrentXRes() const { return current_xres.load(); }
+	int getCurrentYRes() const { return current_yres.load(); }
+
+	// Full target resolution
+	int full_xres, full_yres;
+
+	// Current parameters - use updateParams() to modify and trigger restart
+	SceneParams params;
+
+	// HDR environment map
+	HDREnvironment hdr_env;
+
+private:
+	void managerFunc();
+
+	int num_threads;
+	std::thread manager_thread;
+	bool running = false;
+
+	std::atomic<uint64_t> generation{0};
+	std::atomic<int> completed_passes{0};
+	std::atomic<int> current_xres{0};
+	std::atomic<int> current_yres{0};
+
+	std::mutex params_mutex;
+
+	Scene scene;
+	std::mutex scene_mutex;
+};

--- a/src/ui/RenderController.h
+++ b/src/ui/RenderController.h
@@ -48,6 +48,9 @@ struct RenderController
 	// HDR environment map
 	HDREnvironment hdr_env;
 
+	// True when a pass is complete and output is safe to read (no workers writing)
+	std::atomic<bool> display_ready{false};
+
 private:
 	void managerFunc();
 

--- a/src/ui/RenderController.h
+++ b/src/ui/RenderController.h
@@ -39,8 +39,8 @@ struct RenderController
 	int getCurrentXRes() const { return current_xres.load(); }
 	int getCurrentYRes() const { return current_yres.load(); }
 
-	// Full target resolution
-	int full_xres, full_yres;
+	// Full target resolution (written by UI thread, read by render thread)
+	std::atomic<int> full_xres, full_yres;
 
 	// Current parameters - use updateParams() to modify and trigger restart
 	SceneParams params;

--- a/src/ui/RenderController.h
+++ b/src/ui/RenderController.h
@@ -48,10 +48,6 @@ struct RenderController
 	// HDR environment map
 	HDREnvironment hdr_env;
 
-	// Set to completed_passes value after each pass finishes (output is valid).
-	// Reset to 0 when output is resized/cleared (output is invalid).
-	// The UI updates the display when this advances past its last-seen value.
-	std::atomic<int> safe_display_passes{0};
 
 private:
 	void managerFunc();
@@ -66,7 +62,4 @@ private:
 	std::atomic<int> current_yres{0};
 
 	std::mutex params_mutex;
-
-	Scene scene;
-	std::mutex scene_mutex;
 };

--- a/src/ui/SceneSerializer.cpp
+++ b/src/ui/SceneSerializer.cpp
@@ -1,0 +1,282 @@
+#include "SceneSerializer.h"
+
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+
+// vec3r serialization
+static json vec3rToJson(const vec3r & v) { return { v.x(), v.y(), v.z() }; }
+static vec3r jsonToVec3r(const json & j) { return { (real)j[0], (real)j[1], (real)j[2] }; }
+
+// vec3f serialization
+static json vec3fToJson(const vec3f & v) { return { v.x(), v.y(), v.z() }; }
+static vec3f jsonToVec3f(const json & j) { return { (float)j[0], (float)j[1], (float)j[2] }; }
+
+
+bool saveScene(const std::string & path, const SceneParams & params)
+{
+	json j;
+	j["version"] = 1;
+
+	// Camera
+	auto & cam = j["camera"];
+	cam["position"]         = vec3rToJson(params.camera.position);
+	cam["look_at"]          = vec3rToJson(params.camera.look_at);
+	cam["world_up"]         = vec3rToJson(params.camera.world_up);
+	cam["fov_deg"]          = params.camera.fov_deg;
+	cam["dof_amount"]       = params.camera.dof_amount;
+	cam["lens_radius"]      = params.camera.lens_radius;
+	cam["focal_dist_scale"] = params.camera.focal_dist_scale;
+
+	// Fractal
+	auto & fr = j["fractal"];
+	fr["formula_name"]    = params.fractal.formula_name;
+	fr["radius"]          = params.fractal.radius;
+	fr["scene_scale"]     = params.fractal.scene_scale;
+	fr["step_scale"]      = params.fractal.step_scale;
+	fr["bailout_radius2"] = params.fractal.bailout_radius2;
+	fr["max_iters"]       = params.fractal.max_iters;
+	fr["show_box"]        = params.fractal.show_box;
+
+	// Material
+	auto & mat = j["material"];
+	mat["albedo"]      = vec3fToJson(params.fractal.albedo);
+	mat["emission"]    = vec3fToJson(params.fractal.emission);
+	mat["use_fresnel"] = params.fractal.use_fresnel;
+	mat["r0"]          = params.fractal.r0;
+	mat["use_orbit_trap_colouring"] = params.fractal.use_orbit_trap_colouring;
+
+	// Formula-specific params
+	auto & fp = j["formula_params"];
+	const auto & f = params.fractal;
+	fp["mandalay_scale"]          = f.mandalay_scale;
+	fp["mandalay_min_r2"]         = f.mandalay_min_r2;
+	fp["mandalay_folding_offset"] = f.mandalay_folding_offset;
+	fp["mandalay_z_tower"]        = f.mandalay_z_tower;
+	fp["mandalay_xy_tower"]       = f.mandalay_xy_tower;
+	fp["mandalay_rotate"]         = vec3rToJson(f.mandalay_rotate);
+	fp["mandalay_julia_c"]        = vec3rToJson(f.mandalay_julia_c);
+	fp["mandalay_julia_mode"]     = f.mandalay_julia_mode;
+
+	fp["amazingbox_scale"]      = f.amazingbox_scale;
+	fp["amazingbox_min_r2"]     = f.amazingbox_min_r2;
+	fp["amazingbox_fix_r2"]     = f.amazingbox_fix_r2;
+	fp["amazingbox_fold_limit"] = f.amazingbox_fold_limit;
+	fp["amazingbox_julia_mode"] = f.amazingbox_julia_mode;
+
+	fp["hybrid_amazingbox_scale"]        = f.hybrid_amazingbox_scale;
+	fp["hybrid_amazingbox_fold_limit"]   = f.hybrid_amazingbox_fold_limit;
+	fp["hybrid_amazingbox_min_r2"]       = f.hybrid_amazingbox_min_r2;
+	fp["hybrid_mandalay_scale"]          = f.hybrid_mandalay_scale;
+	fp["hybrid_mandalay_folding_offset"] = f.hybrid_mandalay_folding_offset;
+	fp["hybrid_mandalay_z_tower"]        = f.hybrid_mandalay_z_tower;
+	fp["hybrid_mandalay_xy_tower"]       = f.hybrid_mandalay_xy_tower;
+	fp["hybrid_mandalay_rotate"]         = vec3rToJson(f.hybrid_mandalay_rotate);
+	fp["hybrid_mandalay_julia_mode"]     = f.hybrid_mandalay_julia_mode;
+
+	fp["lambdabulb_power"] = f.lambdabulb_power;
+	fp["lambdabulb_c"]     = vec3rToJson(f.lambdabulb_c);
+
+	fp["octopus_xz_mul"]     = f.octopus_xz_mul;
+	fp["octopus_sq_mul"]     = f.octopus_sq_mul;
+	fp["octopus_julia_mode"] = f.octopus_julia_mode;
+
+	fp["cubicbulb_y_mul"]      = f.cubicbulb_y_mul;
+	fp["cubicbulb_z_mul"]      = f.cubicbulb_z_mul;
+	fp["cubicbulb_aux_mul"]    = f.cubicbulb_aux_mul;
+	fp["cubicbulb_c"]          = vec3rToJson(f.cubicbulb_c);
+	fp["cubicbulb_julia_mode"] = f.cubicbulb_julia_mode;
+
+	fp["benesipine2_scale"]      = f.benesipine2_scale;
+	fp["benesipine2_offset"]     = f.benesipine2_offset;
+	fp["benesipine2_julia_mode"] = f.benesipine2_julia_mode;
+
+	fp["mengersponge_scale"]        = f.mengersponge_scale;
+	fp["mengersponge_scale_centre"] = vec3rToJson(f.mengersponge_scale_centre);
+
+	fp["pseudokleinian_mins"] = { f.pseudokleinian_mins[0], f.pseudokleinian_mins[1], f.pseudokleinian_mins[2], f.pseudokleinian_mins[3] };
+	fp["pseudokleinian_maxs"] = { f.pseudokleinian_maxs[0], f.pseudokleinian_maxs[1], f.pseudokleinian_maxs[2], f.pseudokleinian_maxs[3] };
+
+	fp["riemannsphere_scale"]   = f.riemannsphere_scale;
+	fp["riemannsphere_s_shift"] = f.riemannsphere_s_shift;
+	fp["riemannsphere_t_shift"] = f.riemannsphere_t_shift;
+	fp["riemannsphere_x_shift"] = f.riemannsphere_x_shift;
+	fp["riemannsphere_r_shift"] = f.riemannsphere_r_shift;
+	fp["riemannsphere_r_pow"]   = f.riemannsphere_r_pow;
+
+	fp["hopfbrot_scene_scale"] = f.hopfbrot_scene_scale;
+	fp["sphere_r0"]            = f.sphere_r0;
+
+	// Light
+	auto & lt = j["light"];
+	lt["light_pos"]       = vec3rToJson(params.light.light_pos);
+	lt["light_intensity"] = params.light.light_intensity;
+	lt["sky_up_colour"]   = vec3fToJson(params.light.sky_up_colour);
+	lt["sky_hz_colour"]   = vec3fToJson(params.light.sky_hz_colour);
+	lt["hdr_env_path"]    = params.light.hdr_env_path;
+
+	// Render settings
+	auto & rs = j["render"];
+	rs["max_bounces"]   = params.render.max_bounces;
+	rs["target_passes"] = params.render.target_passes;
+	rs["resolution_x"]  = params.render.resolution_x;
+	rs["resolution_y"]  = params.render.resolution_y;
+
+	std::ofstream file(path);
+	if (!file.is_open()) return false;
+	file << j.dump(2);
+	return true;
+}
+
+
+// Helper to safely read json values with defaults
+template<typename T>
+static T get(const json & j, const std::string & key, const T & def)
+{
+	if (j.contains(key)) return j[key].get<T>();
+	return def;
+}
+
+
+bool loadScene(const std::string & path, SceneParams & params)
+{
+	std::ifstream file(path);
+	if (!file.is_open()) return false;
+
+	json j;
+	try { j = json::parse(file); }
+	catch (...) { return false; }
+
+	FractalParams defaults_fp;
+	CameraParams defaults_cam;
+	LightParams defaults_lt;
+	RenderSettings defaults_rs;
+
+	// Camera
+	if (j.contains("camera"))
+	{
+		auto & cam = j["camera"];
+		if (cam.contains("position"))         params.camera.position         = jsonToVec3r(cam["position"]);
+		if (cam.contains("look_at"))          params.camera.look_at          = jsonToVec3r(cam["look_at"]);
+		if (cam.contains("world_up"))         params.camera.world_up         = jsonToVec3r(cam["world_up"]);
+		params.camera.fov_deg          = get(cam, "fov_deg",          defaults_cam.fov_deg);
+		params.camera.dof_amount       = get(cam, "dof_amount",       defaults_cam.dof_amount);
+		params.camera.lens_radius      = get(cam, "lens_radius",      defaults_cam.lens_radius);
+		params.camera.focal_dist_scale = get(cam, "focal_dist_scale", defaults_cam.focal_dist_scale);
+		params.camera.recompute();
+	}
+
+	// Fractal
+	if (j.contains("fractal"))
+	{
+		auto & fr = j["fractal"];
+		params.fractal.formula_name    = get<std::string>(fr, "formula_name", defaults_fp.formula_name);
+		params.fractal.radius          = get(fr, "radius",          defaults_fp.radius);
+		params.fractal.scene_scale     = get(fr, "scene_scale",     defaults_fp.scene_scale);
+		params.fractal.step_scale      = get(fr, "step_scale",      defaults_fp.step_scale);
+		params.fractal.bailout_radius2 = get(fr, "bailout_radius2", defaults_fp.bailout_radius2);
+		params.fractal.max_iters       = get(fr, "max_iters",       defaults_fp.max_iters);
+		params.fractal.show_box        = get(fr, "show_box",        defaults_fp.show_box);
+	}
+
+	// Material
+	if (j.contains("material"))
+	{
+		auto & mat = j["material"];
+		if (mat.contains("albedo"))   params.fractal.albedo   = jsonToVec3f(mat["albedo"]);
+		if (mat.contains("emission")) params.fractal.emission = jsonToVec3f(mat["emission"]);
+		params.fractal.use_fresnel = get(mat, "use_fresnel", defaults_fp.use_fresnel);
+		params.fractal.r0          = get(mat, "r0",          defaults_fp.r0);
+		params.fractal.use_orbit_trap_colouring = get(mat, "use_orbit_trap_colouring", defaults_fp.use_orbit_trap_colouring);
+	}
+
+	// Formula-specific params
+	if (j.contains("formula_params"))
+	{
+		auto & fp = j["formula_params"];
+		auto & f = params.fractal;
+
+		f.mandalay_scale          = get(fp, "mandalay_scale",          defaults_fp.mandalay_scale);
+		f.mandalay_min_r2         = get(fp, "mandalay_min_r2",         defaults_fp.mandalay_min_r2);
+		f.mandalay_folding_offset = get(fp, "mandalay_folding_offset", defaults_fp.mandalay_folding_offset);
+		f.mandalay_z_tower        = get(fp, "mandalay_z_tower",        defaults_fp.mandalay_z_tower);
+		f.mandalay_xy_tower       = get(fp, "mandalay_xy_tower",       defaults_fp.mandalay_xy_tower);
+		if (fp.contains("mandalay_rotate"))  f.mandalay_rotate = jsonToVec3r(fp["mandalay_rotate"]);
+		if (fp.contains("mandalay_julia_c")) f.mandalay_julia_c = jsonToVec3r(fp["mandalay_julia_c"]);
+		f.mandalay_julia_mode = get(fp, "mandalay_julia_mode", defaults_fp.mandalay_julia_mode);
+
+		f.amazingbox_scale      = get(fp, "amazingbox_scale",      defaults_fp.amazingbox_scale);
+		f.amazingbox_min_r2     = get(fp, "amazingbox_min_r2",     defaults_fp.amazingbox_min_r2);
+		f.amazingbox_fix_r2     = get(fp, "amazingbox_fix_r2",     defaults_fp.amazingbox_fix_r2);
+		f.amazingbox_fold_limit = get(fp, "amazingbox_fold_limit", defaults_fp.amazingbox_fold_limit);
+		f.amazingbox_julia_mode = get(fp, "amazingbox_julia_mode", defaults_fp.amazingbox_julia_mode);
+
+		f.hybrid_amazingbox_scale        = get(fp, "hybrid_amazingbox_scale",        defaults_fp.hybrid_amazingbox_scale);
+		f.hybrid_amazingbox_fold_limit   = get(fp, "hybrid_amazingbox_fold_limit",   defaults_fp.hybrid_amazingbox_fold_limit);
+		f.hybrid_amazingbox_min_r2       = get(fp, "hybrid_amazingbox_min_r2",       defaults_fp.hybrid_amazingbox_min_r2);
+		f.hybrid_mandalay_scale          = get(fp, "hybrid_mandalay_scale",          defaults_fp.hybrid_mandalay_scale);
+		f.hybrid_mandalay_folding_offset = get(fp, "hybrid_mandalay_folding_offset", defaults_fp.hybrid_mandalay_folding_offset);
+		f.hybrid_mandalay_z_tower        = get(fp, "hybrid_mandalay_z_tower",        defaults_fp.hybrid_mandalay_z_tower);
+		f.hybrid_mandalay_xy_tower       = get(fp, "hybrid_mandalay_xy_tower",       defaults_fp.hybrid_mandalay_xy_tower);
+		if (fp.contains("hybrid_mandalay_rotate")) f.hybrid_mandalay_rotate = jsonToVec3r(fp["hybrid_mandalay_rotate"]);
+		f.hybrid_mandalay_julia_mode = get(fp, "hybrid_mandalay_julia_mode", defaults_fp.hybrid_mandalay_julia_mode);
+
+		f.lambdabulb_power = get(fp, "lambdabulb_power", defaults_fp.lambdabulb_power);
+		if (fp.contains("lambdabulb_c")) f.lambdabulb_c = jsonToVec3r(fp["lambdabulb_c"]);
+
+		f.octopus_xz_mul     = get(fp, "octopus_xz_mul",     defaults_fp.octopus_xz_mul);
+		f.octopus_sq_mul     = get(fp, "octopus_sq_mul",     defaults_fp.octopus_sq_mul);
+		f.octopus_julia_mode = get(fp, "octopus_julia_mode", defaults_fp.octopus_julia_mode);
+
+		f.cubicbulb_y_mul      = get(fp, "cubicbulb_y_mul",      defaults_fp.cubicbulb_y_mul);
+		f.cubicbulb_z_mul      = get(fp, "cubicbulb_z_mul",      defaults_fp.cubicbulb_z_mul);
+		f.cubicbulb_aux_mul    = get(fp, "cubicbulb_aux_mul",    defaults_fp.cubicbulb_aux_mul);
+		if (fp.contains("cubicbulb_c")) f.cubicbulb_c = jsonToVec3r(fp["cubicbulb_c"]);
+		f.cubicbulb_julia_mode = get(fp, "cubicbulb_julia_mode", defaults_fp.cubicbulb_julia_mode);
+
+		f.benesipine2_scale      = get(fp, "benesipine2_scale",      defaults_fp.benesipine2_scale);
+		f.benesipine2_offset     = get(fp, "benesipine2_offset",     defaults_fp.benesipine2_offset);
+		f.benesipine2_julia_mode = get(fp, "benesipine2_julia_mode", defaults_fp.benesipine2_julia_mode);
+
+		f.mengersponge_scale = get(fp, "mengersponge_scale", defaults_fp.mengersponge_scale);
+		if (fp.contains("mengersponge_scale_centre")) f.mengersponge_scale_centre = jsonToVec3r(fp["mengersponge_scale_centre"]);
+
+		if (fp.contains("pseudokleinian_mins")) { auto & a = fp["pseudokleinian_mins"]; for (int i = 0; i < 4; i++) f.pseudokleinian_mins[i] = a[i]; }
+		if (fp.contains("pseudokleinian_maxs")) { auto & a = fp["pseudokleinian_maxs"]; for (int i = 0; i < 4; i++) f.pseudokleinian_maxs[i] = a[i]; }
+
+		f.riemannsphere_scale   = get(fp, "riemannsphere_scale",   defaults_fp.riemannsphere_scale);
+		f.riemannsphere_s_shift = get(fp, "riemannsphere_s_shift", defaults_fp.riemannsphere_s_shift);
+		f.riemannsphere_t_shift = get(fp, "riemannsphere_t_shift", defaults_fp.riemannsphere_t_shift);
+		f.riemannsphere_x_shift = get(fp, "riemannsphere_x_shift", defaults_fp.riemannsphere_x_shift);
+		f.riemannsphere_r_shift = get(fp, "riemannsphere_r_shift", defaults_fp.riemannsphere_r_shift);
+		f.riemannsphere_r_pow   = get(fp, "riemannsphere_r_pow",   defaults_fp.riemannsphere_r_pow);
+
+		f.hopfbrot_scene_scale = get(fp, "hopfbrot_scene_scale", defaults_fp.hopfbrot_scene_scale);
+		f.sphere_r0            = get(fp, "sphere_r0",            defaults_fp.sphere_r0);
+	}
+
+	// Light
+	if (j.contains("light"))
+	{
+		auto & lt = j["light"];
+		if (lt.contains("light_pos"))     params.light.light_pos       = jsonToVec3r(lt["light_pos"]);
+		params.light.light_intensity = get(lt, "light_intensity", defaults_lt.light_intensity);
+		if (lt.contains("sky_up_colour")) params.light.sky_up_colour   = jsonToVec3f(lt["sky_up_colour"]);
+		if (lt.contains("sky_hz_colour")) params.light.sky_hz_colour   = jsonToVec3f(lt["sky_hz_colour"]);
+		params.light.hdr_env_path    = get<std::string>(lt, "hdr_env_path", defaults_lt.hdr_env_path);
+	}
+
+	// Render settings
+	if (j.contains("render"))
+	{
+		auto & rs = j["render"];
+		params.render.max_bounces   = get(rs, "max_bounces",   defaults_rs.max_bounces);
+		params.render.target_passes = get(rs, "target_passes", defaults_rs.target_passes);
+		params.render.resolution_x  = get(rs, "resolution_x",  defaults_rs.resolution_x);
+		params.render.resolution_y  = get(rs, "resolution_y",  defaults_rs.resolution_y);
+	}
+
+	return true;
+}

--- a/src/ui/SceneSerializer.cpp
+++ b/src/ui/SceneSerializer.cpp
@@ -79,6 +79,10 @@ bool saveScene(const std::string & path, const SceneParams & params)
 	fp["lambdabulb_power"] = f.lambdabulb_power;
 	fp["lambdabulb_c"]     = vec3rToJson(f.lambdabulb_c);
 
+	fp["amosersine_scale"]      = f.amosersine_scale;
+	fp["amosersine_julia_c"]    = vec3rToJson(f.amosersine_julia_c);
+	fp["amosersine_julia_mode"] = f.amosersine_julia_mode;
+
 	fp["octopus_xz_mul"]     = f.octopus_xz_mul;
 	fp["octopus_sq_mul"]     = f.octopus_sq_mul;
 	fp["octopus_julia_mode"] = f.octopus_julia_mode;
@@ -119,10 +123,11 @@ bool saveScene(const std::string & path, const SceneParams & params)
 
 	// Render settings
 	auto & rs = j["render"];
-	rs["max_bounces"]   = params.render.max_bounces;
-	rs["target_passes"] = params.render.target_passes;
-	rs["resolution_x"]  = params.render.resolution_x;
-	rs["resolution_y"]  = params.render.resolution_y;
+	rs["max_bounces"]      = params.render.max_bounces;
+	rs["target_passes"]    = params.render.target_passes;
+	rs["resolution_x"]     = params.render.resolution_x;
+	rs["resolution_y"]     = params.render.resolution_y;
+	rs["preview_divisor"]  = params.render.preview_divisor;
 
 	std::ofstream file(path);
 	if (!file.is_open()) return false;
@@ -226,6 +231,10 @@ bool loadScene(const std::string & path, SceneParams & params)
 		f.lambdabulb_power = get(fp, "lambdabulb_power", defaults_fp.lambdabulb_power);
 		if (fp.contains("lambdabulb_c")) f.lambdabulb_c = jsonToVec3r(fp["lambdabulb_c"]);
 
+		f.amosersine_scale      = get(fp, "amosersine_scale",      defaults_fp.amosersine_scale);
+		if (fp.contains("amosersine_julia_c")) f.amosersine_julia_c = jsonToVec3r(fp["amosersine_julia_c"]);
+		f.amosersine_julia_mode = get(fp, "amosersine_julia_mode", defaults_fp.amosersine_julia_mode);
+
 		f.octopus_xz_mul     = get(fp, "octopus_xz_mul",     defaults_fp.octopus_xz_mul);
 		f.octopus_sq_mul     = get(fp, "octopus_sq_mul",     defaults_fp.octopus_sq_mul);
 		f.octopus_julia_mode = get(fp, "octopus_julia_mode", defaults_fp.octopus_julia_mode);
@@ -272,10 +281,11 @@ bool loadScene(const std::string & path, SceneParams & params)
 	if (j.contains("render"))
 	{
 		auto & rs = j["render"];
-		params.render.max_bounces   = get(rs, "max_bounces",   defaults_rs.max_bounces);
-		params.render.target_passes = get(rs, "target_passes", defaults_rs.target_passes);
-		params.render.resolution_x  = get(rs, "resolution_x",  defaults_rs.resolution_x);
-		params.render.resolution_y  = get(rs, "resolution_y",  defaults_rs.resolution_y);
+		params.render.max_bounces     = get(rs, "max_bounces",     defaults_rs.max_bounces);
+		params.render.target_passes   = get(rs, "target_passes",   defaults_rs.target_passes);
+		params.render.resolution_x    = get(rs, "resolution_x",    defaults_rs.resolution_x);
+		params.render.resolution_y    = get(rs, "resolution_y",    defaults_rs.resolution_y);
+		params.render.preview_divisor = get(rs, "preview_divisor", defaults_rs.preview_divisor);
 	}
 
 	return true;

--- a/src/ui/SceneSerializer.h
+++ b/src/ui/SceneSerializer.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <string>
+#include "renderer/SceneParams.h"
+
+
+bool saveScene(const std::string & path, const SceneParams & params);
+bool loadScene(const std::string & path, SceneParams & params);

--- a/src/ui/Timeline.cpp
+++ b/src/ui/Timeline.cpp
@@ -1,0 +1,264 @@
+#include "Timeline.h"
+#include "imgui.h"
+
+#include <cmath>
+#include <cstdio>
+
+
+// Catmull-Rom spline interpolation for a single value
+static float catmullRom(float p0, float p1, float p2, float p3, float t)
+{
+	const float t2 = t * t;
+	const float t3 = t2 * t;
+	return 0.5f * ((2.0f * p1) +
+		(-p0 + p2) * t +
+		(2.0f * p0 - 5.0f * p1 + 4.0f * p2 - p3) * t2 +
+		(-p0 + 3.0f * p1 - 3.0f * p2 + p3) * t3);
+}
+
+static vec3r interpolateVec3r(const vec3r & a, const vec3r & b, float t)
+{
+	return a * (1.0f - t) + b * t;
+}
+
+static vec3f interpolateVec3f(const vec3f & a, const vec3f & b, float t)
+{
+	return a * (1.0f - t) + b * t;
+}
+
+static vec3r catmullRomVec3r(const vec3r & p0, const vec3r & p1, const vec3r & p2, const vec3r & p3, float t)
+{
+	return vec3r{
+		(real)catmullRom((float)p0.x(), (float)p1.x(), (float)p2.x(), (float)p3.x(), t),
+		(real)catmullRom((float)p0.y(), (float)p1.y(), (float)p2.y(), (float)p3.y(), t),
+		(real)catmullRom((float)p0.z(), (float)p1.z(), (float)p2.z(), (float)p3.z(), t)
+	};
+}
+
+
+SceneParams Timeline::evaluate(float t) const
+{
+	if (keyframes.empty())
+		return SceneParams{};
+
+	if (keyframes.size() == 1)
+	{
+		SceneParams result;
+		result.camera = keyframes[0].camera;
+		result.fractal = keyframes[0].fractal;
+		result.light = keyframes[0].light;
+		return result;
+	}
+
+	// Clamp time
+	t = std::max(keyframes.front().time_seconds, std::min(keyframes.back().time_seconds, t));
+
+	// Find the two keyframes surrounding t
+	int idx = 0;
+	for (int i = 0; i < (int)keyframes.size() - 1; i++)
+	{
+		if (t >= keyframes[i].time_seconds && t <= keyframes[i + 1].time_seconds)
+		{
+			idx = i;
+			break;
+		}
+	}
+
+	const Keyframe & kf0 = keyframes[idx];
+	const Keyframe & kf1 = keyframes[idx + 1];
+
+	const float dt = kf1.time_seconds - kf0.time_seconds;
+	const float local_t = (dt > 1e-6f) ? (t - kf0.time_seconds) / dt : 0;
+
+	SceneParams result;
+
+	// String fields: step interpolation (use left keyframe)
+	result.fractal = kf0.fractal;
+	if (local_t >= 0.5f)
+		result.fractal.formula_name = kf1.fractal.formula_name;
+
+	// Interpolate camera
+	if (kf0.interpolation_mode == 1 && keyframes.size() >= 2)
+	{
+		// Catmull-Rom: get phantom endpoints
+		const int i0 = std::max(0, idx - 1);
+		const int i3 = std::min((int)keyframes.size() - 1, idx + 2);
+		const Keyframe & kfm = keyframes[i0];
+		const Keyframe & kfp = keyframes[i3];
+
+		result.camera.position = catmullRomVec3r(kfm.camera.position, kf0.camera.position, kf1.camera.position, kfp.camera.position, local_t);
+		result.camera.look_at  = catmullRomVec3r(kfm.camera.look_at, kf0.camera.look_at, kf1.camera.look_at, kfp.camera.look_at, local_t);
+	}
+	else
+	{
+		result.camera.position = interpolateVec3r(kf0.camera.position, kf1.camera.position, local_t);
+		result.camera.look_at  = interpolateVec3r(kf0.camera.look_at, kf1.camera.look_at, local_t);
+	}
+	result.camera.fov_deg = (real)catmullRom((float)kf0.camera.fov_deg, (float)kf0.camera.fov_deg, (float)kf1.camera.fov_deg, (float)kf1.camera.fov_deg, local_t);
+	result.camera.world_up = kf0.camera.world_up;
+	result.camera.recompute();
+
+	// Interpolate numeric fractal params
+	result.fractal.radius          = (real)(kf0.fractal.radius * (1 - local_t) + kf1.fractal.radius * local_t);
+	result.fractal.step_scale      = (real)(kf0.fractal.step_scale * (1 - local_t) + kf1.fractal.step_scale * local_t);
+	result.fractal.bailout_radius2 = (real)(kf0.fractal.bailout_radius2 * (1 - local_t) + kf1.fractal.bailout_radius2 * local_t);
+	result.fractal.max_iters = (int)(kf0.fractal.max_iters * (1 - local_t) + kf1.fractal.max_iters * local_t + 0.5f);
+
+	// Interpolate material
+	result.fractal.albedo = interpolateVec3f(kf0.fractal.albedo, kf1.fractal.albedo, local_t);
+	result.fractal.use_fresnel = kf0.fractal.use_fresnel;
+	result.fractal.r0 = kf0.fractal.r0 * (1 - local_t) + kf1.fractal.r0 * local_t;
+
+	// Interpolate light
+	result.light.light_pos       = interpolateVec3r(kf0.light.light_pos, kf1.light.light_pos, local_t);
+	result.light.light_intensity = (real)(kf0.light.light_intensity * (1 - local_t) + kf1.light.light_intensity * local_t);
+	result.light.sky_up_colour   = interpolateVec3f(kf0.light.sky_up_colour, kf1.light.sky_up_colour, local_t);
+	result.light.sky_hz_colour   = interpolateVec3f(kf0.light.sky_hz_colour, kf1.light.sky_hz_colour, local_t);
+
+	return result;
+}
+
+
+void Timeline::addKeyframe(const Keyframe & kf)
+{
+	// Insert in sorted order
+	auto it = std::lower_bound(keyframes.begin(), keyframes.end(), kf,
+		[](const Keyframe & a, const Keyframe & b) { return a.time_seconds < b.time_seconds; });
+	keyframes.insert(it, kf);
+}
+
+
+void Timeline::removeKeyframe(int index)
+{
+	if (index >= 0 && index < (int)keyframes.size())
+		keyframes.erase(keyframes.begin() + index);
+}
+
+
+bool drawTimelinePanel(Timeline & timeline, SceneParams & params)
+{
+	bool changed = false;
+
+	ImGui::SetNextWindowPos(ImVec2(0, ImGui::GetIO().DisplaySize.y - 180), ImGuiCond_FirstUseEver);
+	ImGui::SetNextWindowSize(ImVec2(ImGui::GetIO().DisplaySize.x, 180), ImGuiCond_FirstUseEver);
+
+	if (!ImGui::Begin("Timeline"))
+	{
+		ImGui::End();
+		return false;
+	}
+
+	// Transport controls
+	if (ImGui::Button(timeline.playing ? "Pause" : "Play"))
+		timeline.playing = !timeline.playing;
+
+	ImGui::SameLine();
+	if (ImGui::Button("Stop"))
+	{
+		timeline.playing = false;
+		timeline.current_time = 0;
+		changed = true;
+	}
+
+	ImGui::SameLine();
+	if (ImGui::Button("Set Keyframe"))
+	{
+		Keyframe kf;
+		kf.time_seconds = timeline.current_time;
+		kf.camera = params.camera;
+		kf.fractal = params.fractal;
+		kf.light = params.light;
+		timeline.addKeyframe(kf);
+	}
+
+	ImGui::SameLine();
+	ImGui::SliderFloat("Duration", &timeline.duration_seconds, 1.0f, 120.0f, "%.1f s");
+
+	ImGui::SameLine();
+	ImGui::SliderInt("FPS", &timeline.fps, 1, 120);
+
+	// Time scrubber
+	if (ImGui::SliderFloat("Time", &timeline.current_time, 0, timeline.duration_seconds, "%.2f s"))
+		changed = true;
+
+	// Keyframe markers visualization
+	ImVec2 canvas_pos = ImGui::GetCursorScreenPos();
+	ImVec2 canvas_size = ImVec2(ImGui::GetContentRegionAvail().x, 30);
+	ImDrawList * draw_list = ImGui::GetWindowDrawList();
+
+	// Background bar
+	draw_list->AddRectFilled(canvas_pos,
+		ImVec2(canvas_pos.x + canvas_size.x, canvas_pos.y + canvas_size.y),
+		IM_COL32(40, 40, 40, 255));
+
+	// Keyframe markers
+	int delete_idx = -1;
+	for (int i = 0; i < (int)timeline.keyframes.size(); i++)
+	{
+		const float t = timeline.keyframes[i].time_seconds;
+		const float x = canvas_pos.x + (t / timeline.duration_seconds) * canvas_size.x;
+		const float y = canvas_pos.y + canvas_size.y * 0.5f;
+
+		// Diamond marker
+		draw_list->AddQuadFilled(
+			ImVec2(x, y - 8), ImVec2(x + 6, y),
+			ImVec2(x, y + 8), ImVec2(x - 6, y),
+			IM_COL32(255, 200, 50, 255));
+
+		// Tooltip/context on hover
+		ImGui::SetCursorScreenPos(ImVec2(x - 8, canvas_pos.y));
+		char id[32];
+		snprintf(id, sizeof(id), "##kf%d", i);
+		if (ImGui::InvisibleButton(id, ImVec2(16, canvas_size.y)))
+		{
+			timeline.current_time = t;
+			changed = true;
+		}
+		if (ImGui::IsItemHovered())
+		{
+			ImGui::BeginTooltip();
+			ImGui::Text("Keyframe %d at %.2f s", i, t);
+			ImGui::EndTooltip();
+		}
+		if (ImGui::BeginPopupContextItem())
+		{
+			ImGui::Text("Keyframe %d", i);
+			if (ImGui::Button("Delete"))
+			{
+				delete_idx = i;
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::EndPopup();
+		}
+	}
+
+	if (delete_idx >= 0)
+		timeline.removeKeyframe(delete_idx);
+
+	// Playhead
+	{
+		const float x = canvas_pos.x + (timeline.current_time / timeline.duration_seconds) * canvas_size.x;
+		draw_list->AddLine(
+			ImVec2(x, canvas_pos.y),
+			ImVec2(x, canvas_pos.y + canvas_size.y),
+			IM_COL32(255, 80, 80, 255), 2.0f);
+	}
+
+	ImGui::SetCursorScreenPos(ImVec2(canvas_pos.x, canvas_pos.y + canvas_size.y + 4));
+
+	// Info
+	ImGui::Text("Keyframes: %d | Total frames: %d", (int)timeline.keyframes.size(), timeline.getTotalFrames());
+
+	ImGui::End();
+
+	// Evaluate timeline during playback
+	if (changed && !timeline.keyframes.empty())
+	{
+		SceneParams interpolated = timeline.evaluate(timeline.current_time);
+		params.camera = interpolated.camera;
+		params.fractal = interpolated.fractal;
+		params.light = interpolated.light;
+	}
+
+	return changed;
+}

--- a/src/ui/Timeline.h
+++ b/src/ui/Timeline.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <vector>
+#include <algorithm>
+#include "renderer/SceneParams.h"
+
+
+struct Keyframe
+{
+	float time_seconds = 0;
+	CameraParams camera;
+	FractalParams fractal;
+	LightParams light;
+	int interpolation_mode = 1; // 0=linear, 1=catmull-rom
+};
+
+
+struct Timeline
+{
+	std::vector<Keyframe> keyframes;
+	float duration_seconds = 10.0f;
+	float current_time = 0;
+	bool playing = false;
+	int fps = 30;
+
+	// Evaluate the timeline at time t, interpolating between keyframes
+	SceneParams evaluate(float t) const;
+
+	// Add a keyframe (inserted in sorted order by time)
+	void addKeyframe(const Keyframe & kf);
+
+	// Remove a keyframe by index
+	void removeKeyframe(int index);
+
+	// Get total number of frames
+	int getTotalFrames() const { return (int)(duration_seconds * fps); }
+};
+
+
+// Timeline UI panel. Returns true if scene params changed (during playback or scrubbing).
+bool drawTimelinePanel(Timeline & timeline, SceneParams & params);

--- a/src/ui/main_ui.cpp
+++ b/src/ui/main_ui.cpp
@@ -223,6 +223,7 @@ int main(int argc, char ** argv)
 		// Stats overlay
 		force_refresh |= drawStatsOverlay(
 			controller.getCompletedPasses(),
+			controller.params.render.target_passes,
 			controller.getCurrentXRes(),
 			controller.getCurrentYRes(),
 			fps);

--- a/src/ui/main_ui.cpp
+++ b/src/ui/main_ui.cpp
@@ -106,8 +106,7 @@ int main(int argc, char ** argv)
 	// Setup Dear ImGui
 	IMGUI_CHECKVERSION();
 	ImGui::CreateContext();
-	ImGuiIO & io = ImGui::GetIO();
-	io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+	// Note: NavEnableKeyboard is intentionally NOT set — it conflicts with WASD camera controls
 	ImGui::StyleColorsDark();
 
 	ImGui_ImplSDL2_InitForSDLRenderer(window, sdl_renderer);

--- a/src/ui/main_ui.cpp
+++ b/src/ui/main_ui.cpp
@@ -269,15 +269,18 @@ int main(int argc, char ** argv)
 
 		if (cur_passes > 0 && cur_passes != last_displayed_passes)
 		{
+			// 4 sub-res passes (1/16, 1/8, 1/4, 1/2) then full-res accumulation
+			constexpr int sub_res_passes = 4;
+
 			if (force_refresh)
 				should_update = true;
-			// Always show the first 3 passes (sub-res previews + first full-res)
-			else if (cur_passes <= 3)
+			// Always show sub-res previews + first full-res
+			else if (cur_passes <= sub_res_passes + 1)
 				should_update = true;
 			// After that, only at power-of-two full-res passes
 			else
 			{
-				const int full_res = cur_passes - 2;
+				const int full_res = cur_passes - sub_res_passes;
 				if (full_res > 0 && (full_res & (full_res - 1)) == 0)
 					should_update = true;
 			}

--- a/src/ui/main_ui.cpp
+++ b/src/ui/main_ui.cpp
@@ -1,0 +1,303 @@
+#define _CRT_SECURE_NO_WARNINGS
+#include <stdio.h>
+#include <stdint.h>
+#include <cmath>
+#include <vector>
+#include <algorithm>
+
+#include "maths/vec.h"
+
+#include "renderer/Renderer.h"
+#include "renderer/SceneParams.h"
+#include "renderer/SceneBuilder.h"
+
+#include "RenderController.h"
+#include "ImGuiPanels.h"
+#include "InteractiveCamera.h"
+#include "Timeline.h"
+#include "AnimationRenderer.h"
+
+#include <SDL2/SDL.h>
+#include "imgui.h"
+#include "imgui_impl_sdl2.h"
+#include "imgui_impl_sdlrenderer2.h"
+
+
+struct sRGBPixel
+{
+	uint8_t r;
+	uint8_t g;
+	uint8_t b;
+};
+
+
+static void tonemapToPixels(std::vector<sRGBPixel> & image_LDR, const RenderOutput & output)
+{
+	const int xres = output.xres;
+	const int yres = output.yres;
+	const int passes = std::max(1, output.passes);
+	const float scale = 1.0f / passes;
+
+	const auto sRGB = [](float u) -> float
+	{
+		return (u <= 0.0031308f) ? 12.92f * u : 1.055f * std::pow(u, 0.416667f) - 0.055f;
+	};
+
+	image_LDR.resize(xres * yres);
+
+	for (int y = 0; y < yres; y++)
+	for (int x = 0; x < xres; x++)
+	{
+		const int i = y * xres + x;
+		const vec3f c = output.beauty[i];
+		image_LDR[i] =
+		{
+			(uint8_t)std::max(0.0f, std::min(255.0f, sRGB(c.x() * scale) * 256)),
+			(uint8_t)std::max(0.0f, std::min(255.0f, sRGB(c.y() * scale) * 256)),
+			(uint8_t)std::max(0.0f, std::min(255.0f, sRGB(c.z() * scale) * 256))
+		};
+	}
+}
+
+
+int main(int argc, char ** argv)
+{
+	(void)argc; (void)argv;
+
+	// Init noise table
+	{
+		uint64_t v = 0;
+		HilbertFibonacci(vec2i(1, 0), vec2i(0, 1), 0, noise_size, v);
+	}
+
+	const int window_w = 1280;
+	const int window_h = 720;
+
+	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) < 0)
+	{
+		fprintf(stderr, "SDL_Init failed: %s\n", SDL_GetError());
+		return 1;
+	}
+
+	SDL_Window * window = SDL_CreateWindow(
+		"FractalTracer",
+		SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+		window_w, window_h,
+		SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
+
+	if (!window)
+	{
+		fprintf(stderr, "SDL_CreateWindow failed: %s\n", SDL_GetError());
+		SDL_Quit();
+		return 1;
+	}
+
+	SDL_Renderer * sdl_renderer = SDL_CreateRenderer(window, -1,
+		SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+
+	if (!sdl_renderer)
+	{
+		fprintf(stderr, "SDL_CreateRenderer failed: %s\n", SDL_GetError());
+		SDL_DestroyWindow(window);
+		SDL_Quit();
+		return 1;
+	}
+
+	// Setup Dear ImGui
+	IMGUI_CHECKVERSION();
+	ImGui::CreateContext();
+	ImGuiIO & io = ImGui::GetIO();
+	io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+	ImGui::StyleColorsDark();
+
+	ImGui_ImplSDL2_InitForSDLRenderer(window, sdl_renderer);
+	ImGui_ImplSDLRenderer2_Init(sdl_renderer);
+
+	// Set up render controller
+	const int num_threads = std::max(1, (int)std::thread::hardware_concurrency());
+	RenderController controller(num_threads, window_w, window_h);
+
+	// Set default camera
+	controller.params.camera.position = vec3r{ 10, 5, -10 } * 0.25f;
+	controller.params.camera.look_at  = { 0, -0.125f, 0 };
+	controller.params.camera.recompute();
+
+	controller.updateParams(controller.params);
+	controller.start();
+
+	// Interactive camera
+	InteractiveCamera interactive_cam;
+	interactive_cam.initFromCamera(controller.params.camera);
+
+	// Timeline
+	Timeline timeline;
+
+	// Animation renderer
+	AnimationRenderer anim_renderer;
+	AnimationSettings anim_settings;
+
+	// Display texture
+	SDL_Texture * texture = nullptr;
+	int tex_w = 0, tex_h = 0;
+	std::vector<sRGBPixel> display_pixels;
+
+	Uint64 last_time = SDL_GetPerformanceCounter();
+	float fps = 0;
+
+	bool quit = false;
+	while (!quit)
+	{
+		// Timing
+		const Uint64 now = SDL_GetPerformanceCounter();
+		const float dt = (float)(now - last_time) / SDL_GetPerformanceFrequency();
+		last_time = now;
+		fps = fps * 0.95f + (1.0f / std::max(dt, 0.001f)) * 0.05f;
+
+		// Poll events
+		bool params_changed = false;
+		SDL_Event event;
+		while (SDL_PollEvent(&event))
+		{
+			ImGui_ImplSDL2_ProcessEvent(&event);
+
+			if (event.type == SDL_QUIT) quit = true;
+			if (event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_ESCAPE) quit = true;
+
+			if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_RESIZED)
+			{
+				controller.full_xres = event.window.data1;
+				controller.full_yres = event.window.data2;
+				params_changed = true;
+			}
+
+			// Interactive camera mouse events
+			params_changed |= interactive_cam.processEvent(event, controller.params.camera);
+		}
+
+		// Interactive camera keyboard movement
+		const Uint8 * keyboard = SDL_GetKeyboardState(nullptr);
+		params_changed |= interactive_cam.update(dt, keyboard, controller.params.camera);
+
+		// Start ImGui frame
+		ImGui_ImplSDLRenderer2_NewFrame();
+		ImGui_ImplSDL2_NewFrame();
+		ImGui::NewFrame();
+
+		// Draw parameter panels
+		ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(350, (float)window_h), ImGuiCond_FirstUseEver);
+		if (ImGui::Begin("Parameters"))
+		{
+			params_changed |= drawFormulaPanel(controller.params.fractal);
+			if (drawCameraPanel(controller.params.camera))
+			{
+				params_changed = true;
+				interactive_cam.initFromCamera(controller.params.camera);
+			}
+			params_changed |= drawMaterialPanel(controller.params.fractal);
+			params_changed |= drawLightPanel(controller.params.light);
+			params_changed |= drawRenderSettingsPanel(controller.params.render);
+
+			ImGui::Separator();
+			ImGui::Checkbox("Orbit Mode (Tab)", &interactive_cam.orbit_mode);
+			ImGui::SliderFloat("Move Speed", &interactive_cam.move_speed, 0.1f, 10.0f);
+			ImGui::SliderFloat("Mouse Sensitivity", &interactive_cam.mouse_sensitivity, 0.001f, 0.01f);
+
+			ImGui::Separator();
+			if (drawFileMenu(controller.params))
+			{
+				params_changed = true;
+				interactive_cam.initFromCamera(controller.params.camera);
+			}
+
+			ImGui::Separator();
+			drawAnimationPanel(anim_renderer, anim_settings, timeline, controller.params, num_threads);
+		}
+		ImGui::End();
+
+		// Stats overlay
+		drawStatsOverlay(
+			controller.getCompletedPasses(),
+			controller.getCurrentXRes(),
+			controller.getCurrentYRes(),
+			fps);
+
+		// Timeline panel
+		if (drawTimelinePanel(timeline, controller.params))
+		{
+			params_changed = true;
+			interactive_cam.initFromCamera(controller.params.camera);
+		}
+
+		// Timeline playback
+		if (timeline.playing && !timeline.keyframes.empty())
+		{
+			timeline.current_time += dt;
+			if (timeline.current_time > timeline.duration_seconds)
+			{
+				timeline.current_time = 0;
+				timeline.playing = false;
+			}
+			else
+			{
+				SceneParams interpolated = timeline.evaluate(timeline.current_time);
+				controller.params.camera = interpolated.camera;
+				controller.params.fractal = interpolated.fractal;
+				controller.params.light = interpolated.light;
+				interactive_cam.initFromCamera(controller.params.camera);
+				params_changed = true;
+			}
+		}
+
+		if (params_changed)
+			controller.updateParams(controller.params);
+
+		// Tonemap current render output
+		int cur_xres, cur_yres;
+		{
+			std::lock_guard<std::mutex> lock(controller.output_mutex);
+			cur_xres = controller.output.xres;
+			cur_yres = controller.output.yres;
+			tonemapToPixels(display_pixels, controller.output);
+		}
+
+		// Recreate texture if resolution changed
+		if (cur_xres != tex_w || cur_yres != tex_h)
+		{
+			if (texture) SDL_DestroyTexture(texture);
+			texture = SDL_CreateTexture(sdl_renderer, SDL_PIXELFORMAT_RGB24,
+				SDL_TEXTUREACCESS_STREAMING, cur_xres, cur_yres);
+			tex_w = cur_xres;
+			tex_h = cur_yres;
+		}
+
+		// Upload pixels
+		if (texture && !display_pixels.empty())
+			SDL_UpdateTexture(texture, nullptr, display_pixels.data(), cur_xres * 3);
+
+		// Render scene
+		SDL_RenderClear(sdl_renderer);
+		if (texture)
+			SDL_RenderCopy(sdl_renderer, texture, nullptr, nullptr);
+
+		// Render ImGui on top
+		ImGui::Render();
+		ImGui_ImplSDLRenderer2_RenderDrawData(ImGui::GetDrawData(), sdl_renderer);
+
+		SDL_RenderPresent(sdl_renderer);
+	}
+
+	controller.stop();
+
+	// Cleanup
+	ImGui_ImplSDLRenderer2_Shutdown();
+	ImGui_ImplSDL2_Shutdown();
+	ImGui::DestroyContext();
+
+	if (texture) SDL_DestroyTexture(texture);
+	SDL_DestroyRenderer(sdl_renderer);
+	SDL_DestroyWindow(window);
+	SDL_Quit();
+
+	return 0;
+}


### PR DESCRIPTION
## Summary

- Add **AmoserSine** fractal formula (3D complex sine extension by amoser) as the new default formula
- Build a full **SDL2 + Dear ImGui interactive UI** with real-time parameter editing, camera controls (WASD/mouse orbit), timeline keyframing, and animation rendering
- Overhaul the **progressive subresolution preview** system: configurable divisor (default 32) with doubling passes, double-buffered output to eliminate blank screen flashes
- Add **`--scene <path>`** flag to the CLI batch renderer for loading scene JSON files saved from the UI
- Add **UI frame rate limiter** (default 30fps) and experimental **lazy mode** to reduce idle CPU/GPU usage
- Fix WASD camera controls blocked by ImGui keyboard navigation
- Fix monitor drag detection by polling `SDL_GetWindowSize` every frame
- Fix data race on `full_xres`/`full_yres` with `std::atomic`

## Test plan

- [ ] Build both `FractalTracer` and `FractalTracerUI` targets
- [ ] Launch UI, confirm amosersine renders by default
- [ ] Verify WASD/QE camera movement and mouse orbit work
- [ ] Drag sliders and confirm responsive preview at all resolutions including 4K
- [ ] Drag window between monitors and confirm it adapts
- [ ] Save scene to JSON, load it back, confirm parameters restore
- [ ] Run CLI with `--scene scene.json` and confirm it renders correctly
- [ ] Test UI Max FPS slider and Lazy Mode checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)